### PR TITLE
CBMC: four proofs

### DIFF
--- a/source/portable/mbedtls/core_pkcs11_mbedtls.c
+++ b/source/portable/mbedtls/core_pkcs11_mbedtls.c
@@ -2749,7 +2749,7 @@ CK_DECLARE_FUNCTION( CK_RV, C_GetAttributeValue )( CK_SESSION_HANDLE hSession,
                         {
                             LogError( ( "Failed to parse attribute template. "
                                         "Received a buffer smaller than CK_OBJECT_CLASS." ) );
-                            xResult = CKR_BUFFER_TOO_SMALL;
+                            xResult = CKR_DATA_LEN_RANGE;
                         }
                     }
 

--- a/source/portable/mbedtls/core_pkcs11_mbedtls.c
+++ b/source/portable/mbedtls/core_pkcs11_mbedtls.c
@@ -3483,7 +3483,7 @@ CK_DECLARE_FUNCTION( CK_RV, C_DigestFinal )( CK_SESSION_HANDLE hSession,
         }
     }
 
-    if( ( xResult != CKR_OK ) && ( xResult != CKR_BUFFER_TOO_SMALL ) &&
+    if( ( xResult != CKR_OK ) && ( xResult != CKR_DATA_LEN_RANGE ) &&
         ( xResult != CKR_SESSION_HANDLE_INVALID ) &&
         ( xResult != CKR_OPERATION_NOT_INITIALIZED ) )
     {

--- a/source/portable/mbedtls/core_pkcs11_mbedtls.c
+++ b/source/portable/mbedtls/core_pkcs11_mbedtls.c
@@ -514,7 +514,7 @@ static CK_RV prvCertAttParse( CK_ATTRIBUTE * pxAttribute,
                             "Consider updating pkcs11configMAX_LABEL_LENGTH.",
                             ( unsigned long int ) pxAttribute->ulValueLen,
                             ( unsigned long int ) pkcs11configMAX_LABEL_LENGTH ) );
-                xResult = CKR_DATA_LEN_RANGE;
+                xResult = CKR_BUFFER_TOO_SMALL;
             }
 
             break;
@@ -3483,7 +3483,7 @@ CK_DECLARE_FUNCTION( CK_RV, C_DigestFinal )( CK_SESSION_HANDLE hSession,
         }
     }
 
-    if( ( xResult != CKR_OK ) && ( xResult != CKR_DATA_LEN_RANGE ) &&
+    if( ( xResult != CKR_OK ) && ( xResult != CKR_BUFFER_TOO_SMALL ) &&
         ( xResult != CKR_SESSION_HANDLE_INVALID ) &&
         ( xResult != CKR_OPERATION_NOT_INITIALIZED ) )
     {
@@ -3783,7 +3783,7 @@ CK_DECLARE_FUNCTION( CK_RV, C_Sign )( CK_SESSION_HANDLE hSession,
                                 "%lu bytes.",
                                 ( unsigned long int ) xExpectedInputLength,
                                 ( unsigned long int ) ulDataLen ) );
-                    xResult = CKR_DATA_LEN_RANGE;
+                    xResult = CKR_BUFFER_TOO_SMALL;
                 }
             }
 
@@ -4111,7 +4111,7 @@ CK_DECLARE_FUNCTION( CK_RV, C_Verify )( CK_SESSION_HANDLE hSession,
             {
                 LogError( ( "Failed verify operation. Data Length was too "
                             "short for pkcs11RSA_2048_SIGNATURE_LENGTH." ) );
-                xResult = CKR_DATA_LEN_RANGE;
+                xResult = CKR_BUFFER_TOO_SMALL;
             }
 
             if( ulSignatureLen != pkcs11RSA_2048_SIGNATURE_LENGTH )
@@ -4129,7 +4129,7 @@ CK_DECLARE_FUNCTION( CK_RV, C_Verify )( CK_SESSION_HANDLE hSession,
             {
                 LogError( ( "Failed verify operation. Data Length was too "
                             "short for pkcs11SHA256_DIGEST_LENGTH." ) );
-                xResult = CKR_DATA_LEN_RANGE;
+                xResult = CKR_BUFFER_TOO_SMALL;
             }
 
             if( ulSignatureLen != pkcs11ECDSA_P256_SIGNATURE_LENGTH )

--- a/source/portable/mbedtls/core_pkcs11_mbedtls.c
+++ b/source/portable/mbedtls/core_pkcs11_mbedtls.c
@@ -3478,7 +3478,7 @@ CK_DECLARE_FUNCTION( CK_RV, C_DigestFinal )( CK_SESSION_HANDLE hSession,
                             "received %lu.",
                             ( unsigned long int ) pkcs11SHA256_DIGEST_LENGTH,
                             ( unsigned long int ) *pulDigestLen ) );
-                xResult = CKR_DATA_LEN_RANGE;
+                xResult = CKR_BUFFER_TOO_SMALL;
             }
         }
     }

--- a/source/portable/mbedtls/core_pkcs11_mbedtls.c
+++ b/source/portable/mbedtls/core_pkcs11_mbedtls.c
@@ -2749,7 +2749,7 @@ CK_DECLARE_FUNCTION( CK_RV, C_GetAttributeValue )( CK_SESSION_HANDLE hSession,
                         {
                             LogError( ( "Failed to parse attribute template. "
                                         "Received a buffer smaller than CK_OBJECT_CLASS." ) );
-                            xResult = CKR_DATA_LEN_RANGE;
+                            xResult = CKR_BUFFER_TOO_SMALL;
                         }
                     }
 

--- a/source/portable/mbedtls/core_pkcs11_mbedtls.c
+++ b/source/portable/mbedtls/core_pkcs11_mbedtls.c
@@ -514,7 +514,7 @@ static CK_RV prvCertAttParse( CK_ATTRIBUTE * pxAttribute,
                             "Consider updating pkcs11configMAX_LABEL_LENGTH.",
                             ( unsigned long int ) pxAttribute->ulValueLen,
                             ( unsigned long int ) pkcs11configMAX_LABEL_LENGTH ) );
-                xResult = CKR_BUFFER_TOO_SMALL;
+                xResult = CKR_DATA_LEN_RANGE;
             }
 
             break;
@@ -3783,7 +3783,7 @@ CK_DECLARE_FUNCTION( CK_RV, C_Sign )( CK_SESSION_HANDLE hSession,
                                 "%lu bytes.",
                                 ( unsigned long int ) xExpectedInputLength,
                                 ( unsigned long int ) ulDataLen ) );
-                    xResult = CKR_BUFFER_TOO_SMALL;
+                    xResult = CKR_DATA_LEN_RANGE;
                 }
             }
 
@@ -4111,7 +4111,7 @@ CK_DECLARE_FUNCTION( CK_RV, C_Verify )( CK_SESSION_HANDLE hSession,
             {
                 LogError( ( "Failed verify operation. Data Length was too "
                             "short for pkcs11RSA_2048_SIGNATURE_LENGTH." ) );
-                xResult = CKR_BUFFER_TOO_SMALL;
+                xResult = CKR_DATA_LEN_RANGE;
             }
 
             if( ulSignatureLen != pkcs11RSA_2048_SIGNATURE_LENGTH )
@@ -4129,7 +4129,7 @@ CK_DECLARE_FUNCTION( CK_RV, C_Verify )( CK_SESSION_HANDLE hSession,
             {
                 LogError( ( "Failed verify operation. Data Length was too "
                             "short for pkcs11SHA256_DIGEST_LENGTH." ) );
-                xResult = CKR_BUFFER_TOO_SMALL;
+                xResult = CKR_DATA_LEN_RANGE;
             }
 
             if( ulSignatureLen != pkcs11ECDSA_P256_SIGNATURE_LENGTH )

--- a/source/portable/mbedtls/core_pkcs11_mbedtls.c
+++ b/source/portable/mbedtls/core_pkcs11_mbedtls.c
@@ -3457,16 +3457,7 @@ CK_DECLARE_FUNCTION( CK_RV, C_DigestFinal )( CK_SESSION_HANDLE hSession,
         }
         else
         {
-            if( *pulDigestLen < ( CK_ULONG ) pkcs11SHA256_DIGEST_LENGTH )
-            {
-                LogError( ( "Failed to finish digest operation. Received a "
-                            "buffer that was too small. Expected %lu and "
-                            "received %lu.",
-                            ( unsigned long int ) pkcs11SHA256_DIGEST_LENGTH,
-                            ( unsigned long int ) *pulDigestLen ) );
-                xResult = CKR_BUFFER_TOO_SMALL;
-            }
-            else
+            if( *pulDigestLen == ( CK_ULONG ) pkcs11SHA256_DIGEST_LENGTH )
             {
                 lMbedTLSResult = mbedtls_sha256_finish_ret( &pxSession->xSHA256Context, pDigest );
 
@@ -3481,6 +3472,15 @@ CK_DECLARE_FUNCTION( CK_RV, C_DigestFinal )( CK_SESSION_HANDLE hSession,
                 }
 
                 pxSession->xOperationDigestMechanism = pkcs11NO_OPERATION;
+            }
+            else
+            {
+                LogError( ( "Failed to finish digest operation. Received a "
+                            "buffer that was an unexpected size. Expected %lu and "
+                            "received %lu.",
+                            ( unsigned long int ) pkcs11SHA256_DIGEST_LENGTH,
+                            ( unsigned long int ) *pulDigestLen ) );
+                xResult = CKR_DATA_LEN_RANGE;
             }
         }
     }

--- a/source/portable/mbedtls/core_pkcs11_mbedtls.c
+++ b/source/portable/mbedtls/core_pkcs11_mbedtls.c
@@ -969,9 +969,7 @@ static CK_RV prvDeleteObjectFromList( CK_OBJECT_HANDLE xAppHandle )
 {
     CK_RV xResult = CKR_OK;
     int32_t lGotSemaphore = ( int32_t ) 0;
-    CK_OBJECT_HANDLE ulIndex = CK_INVALID_HANDLE;
-
-    ulIndex = xAppHandle - ( ( CK_OBJECT_HANDLE ) 1 );
+    CK_OBJECT_HANDLE ulIndex = xAppHandle - ( ( CK_OBJECT_HANDLE ) 1 );
 
     lGotSemaphore = mbedtls_mutex_lock( &xP11Context.xObjectList.xMutex );
 

--- a/source/portable/mbedtls/core_pkcs11_mbedtls.c
+++ b/source/portable/mbedtls/core_pkcs11_mbedtls.c
@@ -410,9 +410,7 @@ static CK_BBOOL prvOperationActive( const P11Session_t * pxSession )
 }
 
 /**
- * @brief Initialize mbedTLS
- * @note: Before prvMbedTLS_Initialize can be called, CRYPTO_Init()
- * must be called to initialize the mbedTLS mutex functions.
+ * @brief Initialize mbedTLS.
  */
 static CK_RV prvMbedTLS_Initialize( void )
 {
@@ -971,7 +969,9 @@ static CK_RV prvDeleteObjectFromList( CK_OBJECT_HANDLE xAppHandle )
 {
     CK_RV xResult = CKR_OK;
     int32_t lGotSemaphore = ( int32_t ) 0;
-    CK_OBJECT_HANDLE ulIndex = xAppHandle - ( ( CK_OBJECT_HANDLE ) 1 );
+    CK_OBJECT_HANDLE ulIndex = CK_INVALID_HANDLE;
+
+    ulIndex = xAppHandle - ( ( CK_OBJECT_HANDLE ) 1 );
 
     lGotSemaphore = mbedtls_mutex_lock( &xP11Context.xObjectList.xMutex );
 
@@ -2566,6 +2566,11 @@ CK_DECLARE_FUNCTION( CK_RV, C_DestroyObject )( CK_SESSION_HANDLE hSession,
 {
     const P11Session_t * pxSession = prvSessionPointerFromHandle( hSession );
     CK_RV xResult = prvCheckValidSessionAndModule( pxSession );
+
+    if( ( hObject < 1UL ) || ( hObject > pkcs11configMAX_NUM_OBJECTS ) )
+    {
+        xResult = CKR_OBJECT_HANDLE_INVALID;
+    }
 
     if( xResult == CKR_OK )
     {

--- a/test/cbmc/proofs/C_DestroyObject/C_DestroyObject_harness.c
+++ b/test/cbmc/proofs/C_DestroyObject/C_DestroyObject_harness.c
@@ -76,12 +76,29 @@ void __CPROVER_file_local_core_pkcs11_mbedtls_c_prvFindObjectInListByHandle( CK_
 
     __CPROVER_assume( handle < 4 );
     *pxPalHandle = handle;
+
+    if( nondet_bool() )
+    {
+        *ppcLabel = pkcs11configLABEL_DEVICE_PRIVATE_KEY_FOR_TLS;
+        *pxLabelLength = sizeof( pkcs11configLABEL_DEVICE_PRIVATE_KEY_FOR_TLS );
+    }
+    else
+    {
+        *ppcLabel = pkcs11configLABEL_DEVICE_PUBLIC_KEY_FOR_TLS;
+        *pxLabelLength = sizeof( pkcs11configLABEL_DEVICE_PUBLIC_KEY_FOR_TLS );
+    }
+
 }
 
 void harness()
 {
     CK_SESSION_HANDLE hSession;
     CK_OBJECT_HANDLE hObject;
+
+    /* We need to populate the PKCS module with mutexes. Rather than stubbing out
+     * some critical paths, we can just initialize the module.
+     */
+    ( void ) C_Initialize( NULL );
 
 __CPROVER_assume( hSession >= 1 && hSession <= pkcs11configMAX_SESSIONS );
   C_DestroyObject( hSession, hObject );

--- a/test/cbmc/proofs/C_DestroyObject/C_DestroyObject_harness.c
+++ b/test/cbmc/proofs/C_DestroyObject/C_DestroyObject_harness.c
@@ -93,12 +93,14 @@ void harness()
 {
     CK_SESSION_HANDLE hSession;
     CK_OBJECT_HANDLE hObject;
+    CK_RV xResult;
 
     /* We need to populate the PKCS module with mutexes. Rather than stubbing out
      * some critical paths, we can just initialize the module.
      */
-    ( void ) C_Initialize( NULL );
+    xResult = C_Initialize( NULL );
+    __CPROVER_assume( xResult == CKR_OK );
 
     __CPROVER_assume( hSession >= 1 && hSession <= pkcs11configMAX_SESSIONS );
-    C_DestroyObject( hSession, hObject );
+    ( void ) C_DestroyObject( hSession, hObject );
 }

--- a/test/cbmc/proofs/C_DestroyObject/C_DestroyObject_harness.c
+++ b/test/cbmc/proofs/C_DestroyObject/C_DestroyObject_harness.c
@@ -87,7 +87,6 @@ void __CPROVER_file_local_core_pkcs11_mbedtls_c_prvFindObjectInListByHandle( CK_
         *ppcLabel = pkcs11configLABEL_DEVICE_PUBLIC_KEY_FOR_TLS;
         *pxLabelLength = sizeof( pkcs11configLABEL_DEVICE_PUBLIC_KEY_FOR_TLS );
     }
-
 }
 
 void harness()
@@ -100,6 +99,6 @@ void harness()
      */
     ( void ) C_Initialize( NULL );
 
-__CPROVER_assume( hSession >= 1 && hSession <= pkcs11configMAX_SESSIONS );
-  C_DestroyObject( hSession, hObject );
+    __CPROVER_assume( hSession >= 1 && hSession <= pkcs11configMAX_SESSIONS );
+    C_DestroyObject( hSession, hObject );
 }

--- a/test/cbmc/proofs/C_DestroyObject/C_DestroyObject_harness.c
+++ b/test/cbmc/proofs/C_DestroyObject/C_DestroyObject_harness.c
@@ -1,0 +1,88 @@
+/*
+ * corePKCS11 V2.0.0
+ * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+ * the Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+ * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ *
+ * http://aws.amazon.com/freertos
+ * http://www.FreeRTOS.org
+ */
+
+/**
+ * @file C_DestroyObject_harness.c
+ * @brief Implements the proof harness for C_DestroyObject function.
+ */
+#include "mbedtls/ecp.h"
+#include "mbedtls/oid.h"
+#include "mbedtls/sha256.h"
+#include "mbedtls/pk.h"
+#include "core_pkcs11_config.h"
+#include "core_pkcs11.h"
+
+/* Internal struct for corePKCS11 mbed TLS implementation, but we don't really care what it contains
+ * in this proof.
+ *
+ * It is just copied over from "core_pkcs11_mbedtls.c" so the structure is correct.
+ */
+typedef struct P11Session
+{
+    CK_ULONG ulState;
+    CK_BBOOL xOpened;
+    CK_MECHANISM_TYPE xOperationDigestMechanism;
+    CK_BYTE * pxFindObjectLabel;
+    CK_ULONG xFindObjectLabelLen;
+    CK_MECHANISM_TYPE xOperationVerifyMechanism;
+    mbedtls_threading_mutex_t xVerifyMutex;
+    CK_OBJECT_HANDLE xVerifyKeyHandle;
+    mbedtls_pk_context xVerifyKey;
+    CK_MECHANISM_TYPE xOperationSignMechanism;
+    mbedtls_threading_mutex_t xSignMutex;
+    CK_OBJECT_HANDLE xSignKeyHandle;
+    mbedtls_pk_context xSignKey;
+    mbedtls_sha256_context xSHA256Context;
+} P11Session_t;
+
+CK_RV __CPROVER_file_local_core_pkcs11_mbedtls_c_prvCheckValidSessionAndModule( const P11Session_t * pxSession )
+{
+    __CPROVER_assert( pxSession != NULL, "pxSession was NULL." );
+    return CKR_OK;
+}
+
+void __CPROVER_file_local_core_pkcs11_mbedtls_c_prvFindObjectInListByHandle( CK_OBJECT_HANDLE xAppHandle,
+                                                                             CK_OBJECT_HANDLE_PTR pxPalHandle,
+                                                                             CK_BYTE_PTR * ppcLabel,
+                                                                             CK_ULONG_PTR pxLabelLength )
+{
+    CK_OBJECT_HANDLE handle;
+
+    __CPROVER_assert( pxPalHandle != NULL, "ppcLabel was NULL." );
+    __CPROVER_assert( ppcLabel != NULL, "ppcLabel was NULL." );
+    __CPROVER_assert( pxLabelLength != NULL, "ppcLabel was NULL." );
+
+    __CPROVER_assume( handle < 4 );
+    *pxPalHandle = handle;
+}
+
+void harness()
+{
+    CK_SESSION_HANDLE hSession;
+    CK_OBJECT_HANDLE hObject;
+
+__CPROVER_assume( hSession >= 1 && hSession <= pkcs11configMAX_SESSIONS );
+  C_DestroyObject( hSession, hObject );
+}

--- a/test/cbmc/proofs/C_DestroyObject/Makefile
+++ b/test/cbmc/proofs/C_DestroyObject/Makefile
@@ -1,0 +1,29 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+HARNESS_ENTRY = harness
+HARNESS_FILE = C_DestroyObject_harness
+
+# This should be a unique identifier for this proof, and will appear on the
+# Litani dashboard. It can be human-readable and contain spaces if you wish.
+PROOF_UID = C_DestroyObject
+
+DEFINES +=
+INCLUDES +=
+
+INCLUDES += -I$(SRCDIR)/source/dependency/3rdparty/mbedtls/include
+INCLUDES += -I$(SRCDIR)/source/dependency/3rdparty/mbedtls_utils
+
+REMOVE_FUNCTION_BODY += C_Finalize
+REMOVE_FUNCTION_BODY += C_GetFunctionList
+REMOVE_FUNCTION_BODY += PKCS11_PAL_Initialize
+REMOVE_FUNCTION_BODY +=	C_Initialize
+REMOVE_FUNCTION_BODY +=	C_Initialize
+REMOVE_FUNCTION_BODY +=	__CPROVER_file_local_core_pkcs11_mbedtls_c_prvMbedTLS_Initialize
+UNWINDSET +=
+
+PROOF_SOURCES += $(PROOFDIR)/$(HARNESS_FILE).c
+PROOF_SOURCES += $(SRCDIR)/test/cbmc/stubs/core_pkcs11_pal_stubs.c
+PROJECT_SOURCES += $(SRCDIR)/source/portable/mbedtls/core_pkcs11_mbedtls.c
+
+include ../Makefile.common

--- a/test/cbmc/proofs/C_DestroyObject/Makefile
+++ b/test/cbmc/proofs/C_DestroyObject/Makefile
@@ -16,13 +16,14 @@ INCLUDES += -I$(SRCDIR)/source/dependency/3rdparty/mbedtls_utils
 
 REMOVE_FUNCTION_BODY += C_Finalize
 REMOVE_FUNCTION_BODY += C_GetFunctionList
-REMOVE_FUNCTION_BODY += PKCS11_PAL_Initialize
-REMOVE_FUNCTION_BODY +=	C_Initialize
-REMOVE_FUNCTION_BODY +=	C_Initialize
-REMOVE_FUNCTION_BODY +=	__CPROVER_file_local_core_pkcs11_mbedtls_c_prvMbedTLS_Initialize
-UNWINDSET +=
+
+# Same as max label size in the core_pkcs11_config.h
+UNWINDSET += strncmp.0:32
+UNWINDSET += strlen.0:32
+UNWINDSET += __CPROVER_file_local_core_pkcs11_mbedtls_c_prvFindObjectInListByLabel.0:2
 
 PROOF_SOURCES += $(PROOFDIR)/$(HARNESS_FILE).c
+PROOF_SOURCES += $(SRCDIR)/test/cbmc/stubs/mbedtls_stubs.c
 PROOF_SOURCES += $(SRCDIR)/test/cbmc/stubs/core_pkcs11_pal_stubs.c
 PROJECT_SOURCES += $(SRCDIR)/source/portable/mbedtls/core_pkcs11_mbedtls.c
 

--- a/test/cbmc/proofs/C_DestroyObject/README.md
+++ b/test/cbmc/proofs/C_DestroyObject/README.md
@@ -1,0 +1,20 @@
+C_DestroyObject proof
+==============
+
+This directory contains a memory safety proof for C_DestroyObject.
+
+To run the proof.
+-------------
+
+* Add `cbmc`, `goto-cc`, `goto-instrument`, `goto-analyzer`, and `cbmc-viewer`
+  to your path.
+* Run `make`.
+* Open html/index.html in a web browser.
+
+To use [`arpa`](https://github.com/awslabs/aws-proof-build-assistant) to simplify writing Makefiles.
+-------------
+
+* Run `make arpa` to generate a Makefile.arpa that contains relevant build information for the proof.
+* Use Makefile.arpa as the starting point for your proof Makefile by:
+  1. Modifying Makefile.arpa (if required).
+  2. Including Makefile.arpa into the existing proof Makefile (add `sinclude Makefile.arpa` at the bottom of the Makefile, right before `include ../Makefile.common`).

--- a/test/cbmc/proofs/C_DestroyObject/cbmc-proof.txt
+++ b/test/cbmc/proofs/C_DestroyObject/cbmc-proof.txt
@@ -1,0 +1,1 @@
+# This file marks this directory as containing a CBMC proof.

--- a/test/cbmc/proofs/C_DestroyObject/cbmc-viewer.json
+++ b/test/cbmc/proofs/C_DestroyObject/cbmc-viewer.json
@@ -1,0 +1,7 @@
+{ "expected-missing-functions":
+  [
+
+  ],
+  "proof-name": "C_DestroyObject",
+  "proof-root": "test/cbmc/proofs"
+}

--- a/test/cbmc/proofs/C_DigestFinal/C_DigestFinal_harness.c
+++ b/test/cbmc/proofs/C_DigestFinal/C_DigestFinal_harness.c
@@ -80,25 +80,25 @@ void harness()
     CK_BYTE_PTR pPart;
 
     __CPROVER_assume( ulPartlen <= 1024 );
-     pPart = malloc( ulPartlen );
+    pPart = malloc( ulPartlen );
 
-__CPROVER_assume( hSession >= 1 && hSession <= pkcs11configMAX_SESSIONS );
-  xResult = C_DigestFinal( hSession, NULL, &ulRequestedSizeLen );
-  if( xResult == CKR_OK )
-  {
-       __CPROVER_assert( ulRequestedSizeLen == 32, "A NULL buffer pointer indicates a request for the needed"
-               "buffer output size. Since we only do SHA-256, it should always be 32 bytes." );
-  }
+    __CPROVER_assume( hSession >= 1 && hSession <= pkcs11configMAX_SESSIONS );
+    xResult = C_DigestFinal( hSession, NULL, &ulRequestedSizeLen );
 
-   xResult = C_DigestFinal( hSession, pPart, &ulPartlen );
     if( xResult == CKR_OK )
     {
-       __CPROVER_assert( ulPartlen == 32, "A NULL buffer pointer indicates a request for the needed"
-               "buffer output size. Since we only do SHA-256, it should always be 32 bytes." );
-
+        __CPROVER_assert( ulRequestedSizeLen == 32, "A NULL buffer pointer indicates a request for the needed"
+                                                    "buffer output size. Since we only do SHA-256, it should always be 32 bytes." );
     }
-   xResult = C_DigestFinal( hSession, pPart, NULL );
-   __CPROVER_assert( xResult == CKR_ARGUMENTS_BAD, "A NULL length pointer is a bad argument." );
 
-  
+    xResult = C_DigestFinal( hSession, pPart, &ulPartlen );
+
+    if( xResult == CKR_OK )
+    {
+        __CPROVER_assert( ulPartlen == 32, "A NULL buffer pointer indicates a request for the needed"
+                                           "buffer output size. Since we only do SHA-256, it should always be 32 bytes." );
+    }
+
+    xResult = C_DigestFinal( hSession, pPart, NULL );
+    __CPROVER_assert( xResult == CKR_ARGUMENTS_BAD, "A NULL length pointer is a bad argument." );
 }

--- a/test/cbmc/proofs/C_DigestFinal/C_DigestFinal_harness.c
+++ b/test/cbmc/proofs/C_DigestFinal/C_DigestFinal_harness.c
@@ -101,4 +101,6 @@ void harness()
 
     xResult = C_DigestFinal( hSession, pPart, NULL );
     __CPROVER_assert( xResult == CKR_ARGUMENTS_BAD, "A NULL length pointer is a bad argument." );
+
+    free( pPart );
 }

--- a/test/cbmc/proofs/C_DigestFinal/C_DigestFinal_harness.c
+++ b/test/cbmc/proofs/C_DigestFinal/C_DigestFinal_harness.c
@@ -1,0 +1,104 @@
+/*
+ * corePKCS11 V2.0.0
+ * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+ * the Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+ * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ *
+ * http://aws.amazon.com/freertos
+ * http://www.FreeRTOS.org
+ */
+
+/**
+ * @file C_DigestFinal_harness.c
+ * @brief Implements the proof harness for C_DigestFinal function.
+ */
+
+#include "mbedtls/ecp.h"
+#include "mbedtls/oid.h"
+#include "mbedtls/sha256.h"
+#include "mbedtls/pk.h"
+#include "core_pkcs11_config.h"
+#include "core_pkcs11.h"
+
+/* Internal struct for corePKCS11 mbed TLS implementation, but we don't really care what it contains
+ * in this proof.
+ *
+ * It is just copied over from "core_pkcs11_mbedtls.c" so the structure is correct.
+ */
+typedef struct P11Session
+{
+    CK_ULONG ulState;
+    CK_BBOOL xOpened;
+    CK_MECHANISM_TYPE xOperationDigestMechanism;
+    CK_BYTE * pxFindObjectLabel;
+    CK_ULONG xFindObjectLabelLen;
+    CK_MECHANISM_TYPE xOperationVerifyMechanism;
+    mbedtls_threading_mutex_t xVerifyMutex;
+    CK_OBJECT_HANDLE xVerifyKeyHandle;
+    mbedtls_pk_context xVerifyKey;
+    CK_MECHANISM_TYPE xOperationSignMechanism;
+    mbedtls_threading_mutex_t xSignMutex;
+    CK_OBJECT_HANDLE xSignKeyHandle;
+    mbedtls_pk_context xSignKey;
+    mbedtls_sha256_context xSHA256Context;
+} P11Session_t;
+
+CK_RV __CPROVER_file_local_core_pkcs11_mbedtls_c_prvCheckValidSessionAndModule( P11Session_t * pxSession )
+{
+    __CPROVER_assert( pxSession != NULL, "pxSession was NULL." );
+    pxSession->xOperationDigestMechanism = nondet_bool() ? CKM_SHA256 : CKM_SHA224;
+    return CKR_OK;
+}
+
+CK_BBOOL __CPROVER_file_local_core_pkcs11_mbedtls_c_prvOperationActive( const P11Session_t * pxSession )
+{
+    __CPROVER_assert( pxSession != NULL, "pxSession was NULL." );
+    return nondet_bool() ? CK_TRUE : CK_FALSE;
+}
+
+void harness()
+{
+    CK_SESSION_HANDLE hSession;
+    CK_ULONG ulPartlen;
+    CK_ULONG ulRequestedSizeLen;
+    CK_RV xResult;
+    CK_BYTE_PTR pPart;
+
+    __CPROVER_assume( ulPartlen <= 1024 );
+     pPart = malloc( ulPartlen );
+
+__CPROVER_assume( hSession >= 1 && hSession <= pkcs11configMAX_SESSIONS );
+  xResult = C_DigestFinal( hSession, NULL, &ulRequestedSizeLen );
+  if( xResult == CKR_OK )
+  {
+       __CPROVER_assert( ulRequestedSizeLen == 32, "A NULL buffer pointer indicates a request for the needed"
+               "buffer output size. Since we only do SHA-256, it should always be 32 bytes." );
+  }
+
+   xResult = C_DigestFinal( hSession, pPart, &ulPartlen );
+    if( xResult == CKR_OK )
+    {
+       __CPROVER_assert( ulPartlen == 32, "A NULL buffer pointer indicates a request for the needed"
+               "buffer output size. Since we only do SHA-256, it should always be 32 bytes." );
+
+    }
+   xResult = C_DigestFinal( hSession, pPart, NULL );
+   __CPROVER_assert( xResult == CKR_ARGUMENTS_BAD, "A NULL length pointer is a bad argument." );
+
+  
+}

--- a/test/cbmc/proofs/C_DigestFinal/Makefile
+++ b/test/cbmc/proofs/C_DigestFinal/Makefile
@@ -1,0 +1,22 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+HARNESS_ENTRY = harness
+HARNESS_FILE = C_DigestFinal_harness
+
+# This should be a unique identifier for this proof, and will appear on the
+# Litani dashboard. It can be human-readable and contain spaces if you wish.
+PROOF_UID = C_DigestFinal
+
+DEFINES +=
+INCLUDES += -I$(SRCDIR)/source/dependency/3rdparty/mbedtls/include
+INCLUDES += -I$(SRCDIR)/source/dependency/3rdparty/mbedtls_utils
+
+REMOVE_FUNCTION_BODY +=
+UNWINDSET +=
+
+PROOF_SOURCES += $(PROOFDIR)/$(HARNESS_FILE).c
+PROJECT_SOURCES += $(SRCDIR)/source/portable/mbedtls/core_pkcs11_mbedtls.c
+PROOF_SOURCES += $(SRCDIR)/test/cbmc/stubs/mbedtls_stubs.c
+
+include ../Makefile.common

--- a/test/cbmc/proofs/C_DigestFinal/README.md
+++ b/test/cbmc/proofs/C_DigestFinal/README.md
@@ -1,0 +1,20 @@
+C_DigestFinal proof
+==============
+
+This directory contains a memory safety proof for C_DigestFinal.
+
+To run the proof.
+-------------
+
+* Add `cbmc`, `goto-cc`, `goto-instrument`, `goto-analyzer`, and `cbmc-viewer`
+  to your path.
+* Run `make`.
+* Open html/index.html in a web browser.
+
+To use [`arpa`](https://github.com/awslabs/aws-proof-build-assistant) to simplify writing Makefiles.
+-------------
+
+* Run `make arpa` to generate a Makefile.arpa that contains relevant build information for the proof.
+* Use Makefile.arpa as the starting point for your proof Makefile by:
+  1. Modifying Makefile.arpa (if required).
+  2. Including Makefile.arpa into the existing proof Makefile (add `sinclude Makefile.arpa` at the bottom of the Makefile, right before `include ../Makefile.common`).

--- a/test/cbmc/proofs/C_DigestFinal/cbmc-proof.txt
+++ b/test/cbmc/proofs/C_DigestFinal/cbmc-proof.txt
@@ -1,0 +1,1 @@
+# This file marks this directory as containing a CBMC proof.

--- a/test/cbmc/proofs/C_DigestFinal/cbmc-viewer.json
+++ b/test/cbmc/proofs/C_DigestFinal/cbmc-viewer.json
@@ -1,0 +1,7 @@
+{ "expected-missing-functions":
+  [
+
+  ],
+  "proof-name": "C_DigestFinal",
+  "proof-root": "test/cbmc/proofs"
+}

--- a/test/cbmc/proofs/C_DigestInit/C_DigestInit_harness.c
+++ b/test/cbmc/proofs/C_DigestInit/C_DigestInit_harness.c
@@ -1,0 +1,81 @@
+/*
+ * corePKCS11 V2.0.0
+ * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+ * the Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+ * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ *
+ * http://aws.amazon.com/freertos
+ * http://www.FreeRTOS.org
+ */
+
+/**
+ * @file C_DigestInit_harness.c
+ * @brief Implements the proof harness for C_DigestInit function.
+ */
+
+#include "mbedtls/ecp.h"
+#include "mbedtls/oid.h"
+#include "mbedtls/sha256.h"
+#include "mbedtls/pk.h"
+#include "core_pkcs11_config.h"
+#include "core_pkcs11.h"
+
+/* Internal struct for corePKCS11 mbed TLS implementation, but we don't really care what it contains
+ * in this proof.
+ *
+ * It is just copied over from "core_pkcs11_mbedtls.c" so the structure is correct.
+ */
+typedef struct P11Session
+{
+    CK_ULONG ulState;
+    CK_BBOOL xOpened;
+    CK_MECHANISM_TYPE xOperationDigestMechanism;
+    CK_BYTE * pxFindObjectLabel;
+    CK_ULONG xFindObjectLabelLen;
+    CK_MECHANISM_TYPE xOperationVerifyMechanism;
+    mbedtls_threading_mutex_t xVerifyMutex;
+    CK_OBJECT_HANDLE xVerifyKeyHandle;
+    mbedtls_pk_context xVerifyKey;
+    CK_MECHANISM_TYPE xOperationSignMechanism;
+    mbedtls_threading_mutex_t xSignMutex;
+    CK_OBJECT_HANDLE xSignKeyHandle;
+    mbedtls_pk_context xSignKey;
+    mbedtls_sha256_context xSHA256Context;
+} P11Session_t;
+
+CK_RV __CPROVER_file_local_core_pkcs11_mbedtls_c_prvCheckValidSessionAndModule( const P11Session_t * pxSession )
+{
+    __CPROVER_assert( pxSession != NULL, "pxSession was NULL." );
+    return CKR_OK;
+}
+
+CK_BBOOL __CPROVER_file_local_core_pkcs11_mbedtls_c_prvOperationActive( const P11Session_t * pxSession )
+{
+    __CPROVER_assert( pxSession != NULL, "pxSession was NULL." );
+    return nondet_bool() ? CK_TRUE : CK_FALSE;
+}
+
+void harness()
+{
+    CK_SESSION_HANDLE hSession;
+    CK_MECHANISM xMech;
+
+    __CPROVER_assume( hSession >= 1 && hSession <= pkcs11configMAX_SESSIONS );
+  ( void ) C_DigestInit( hSession, &xMech );
+  ( void ) C_DigestInit( hSession, NULL );
+}

--- a/test/cbmc/proofs/C_DigestInit/C_DigestInit_harness.c
+++ b/test/cbmc/proofs/C_DigestInit/C_DigestInit_harness.c
@@ -77,7 +77,7 @@ void harness()
     CK_RV xResult;
 
     __CPROVER_assume( hSession >= 1 && hSession <= pkcs11configMAX_SESSIONS );
-  ( void ) C_DigestInit( hSession, &xMech );
-   xResult = C_DigestInit( hSession, NULL );
-   __CPROVER_assert( xResult == CKR_ARGUMENTS_BAD, "A NULL mechanism is considered a bad argument." );
+    ( void ) C_DigestInit( hSession, &xMech );
+    xResult = C_DigestInit( hSession, NULL );
+    __CPROVER_assert( xResult == CKR_ARGUMENTS_BAD, "A NULL mechanism is considered a bad argument." );
 }

--- a/test/cbmc/proofs/C_DigestInit/Makefile
+++ b/test/cbmc/proofs/C_DigestInit/Makefile
@@ -1,0 +1,22 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+HARNESS_ENTRY = harness
+HARNESS_FILE = C_DigestInit_harness
+
+# This should be a unique identifier for this proof, and will appear on the
+# Litani dashboard. It can be human-readable and contain spaces if you wish.
+PROOF_UID = C_DigestInit
+
+DEFINES +=
+INCLUDES += -I$(SRCDIR)/source/dependency/3rdparty/mbedtls/include
+INCLUDES += -I$(SRCDIR)/source/dependency/3rdparty/mbedtls_utils
+
+REMOVE_FUNCTION_BODY +=
+UNWINDSET +=
+
+PROOF_SOURCES += $(PROOFDIR)/$(HARNESS_FILE).c
+PROJECT_SOURCES += $(SRCDIR)/source/portable/mbedtls/core_pkcs11_mbedtls.c
+PROOF_SOURCES += $(SRCDIR)/test/cbmc/stubs/mbedtls_stubs.c
+
+include ../Makefile.common

--- a/test/cbmc/proofs/C_DigestInit/README.md
+++ b/test/cbmc/proofs/C_DigestInit/README.md
@@ -1,0 +1,20 @@
+C_DigestInit proof
+==============
+
+This directory contains a memory safety proof for C_DigestInit.
+
+To run the proof.
+-------------
+
+* Add `cbmc`, `goto-cc`, `goto-instrument`, `goto-analyzer`, and `cbmc-viewer`
+  to your path.
+* Run `make`.
+* Open html/index.html in a web browser.
+
+To use [`arpa`](https://github.com/awslabs/aws-proof-build-assistant) to simplify writing Makefiles.
+-------------
+
+* Run `make arpa` to generate a Makefile.arpa that contains relevant build information for the proof.
+* Use Makefile.arpa as the starting point for your proof Makefile by:
+  1. Modifying Makefile.arpa (if required).
+  2. Including Makefile.arpa into the existing proof Makefile (add `sinclude Makefile.arpa` at the bottom of the Makefile, right before `include ../Makefile.common`).

--- a/test/cbmc/proofs/C_DigestInit/cbmc-proof.txt
+++ b/test/cbmc/proofs/C_DigestInit/cbmc-proof.txt
@@ -1,0 +1,1 @@
+# This file marks this directory as containing a CBMC proof.

--- a/test/cbmc/proofs/C_DigestInit/cbmc-viewer.json
+++ b/test/cbmc/proofs/C_DigestInit/cbmc-viewer.json
@@ -1,0 +1,7 @@
+{ "expected-missing-functions":
+  [
+
+  ],
+  "proof-name": "C_DigestInit",
+  "proof-root": "test/cbmc/proofs"
+}

--- a/test/cbmc/proofs/C_DigestUpdate/C_DigestUpdate_harness.c
+++ b/test/cbmc/proofs/C_DigestUpdate/C_DigestUpdate_harness.c
@@ -75,11 +75,14 @@ void harness()
 {
     CK_SESSION_HANDLE hSession;
     CK_ULONG ulPartlen;
+    CK_RV xResult;
 
     /* The length of the data doesn't really matter. */
     __CPROVER_assume( ulPartlen <= 1024 );
     CK_BYTE_PTR pPart = malloc( ulPartlen );
 
 __CPROVER_assume( hSession >= 1 && hSession <= pkcs11configMAX_SESSIONS );
-  C_DigestUpdate( hSession, pPart, ulPartlen );
+  ( void ) C_DigestUpdate( hSession, pPart, ulPartlen );
+  xResult = C_DigestUpdate( hSession, NULL, ulPartlen );
+   __CPROVER_assert( xResult == CKR_ARGUMENTS_BAD, "A NULL buffer is considered a bad argument." );
 }

--- a/test/cbmc/proofs/C_DigestUpdate/C_DigestUpdate_harness.c
+++ b/test/cbmc/proofs/C_DigestUpdate/C_DigestUpdate_harness.c
@@ -81,8 +81,8 @@ void harness()
     __CPROVER_assume( ulPartlen <= 1024 );
     CK_BYTE_PTR pPart = malloc( ulPartlen );
 
-__CPROVER_assume( hSession >= 1 && hSession <= pkcs11configMAX_SESSIONS );
-  ( void ) C_DigestUpdate( hSession, pPart, ulPartlen );
-  xResult = C_DigestUpdate( hSession, NULL, ulPartlen );
-   __CPROVER_assert( xResult == CKR_ARGUMENTS_BAD, "A NULL buffer is considered a bad argument." );
+    __CPROVER_assume( hSession >= 1 && hSession <= pkcs11configMAX_SESSIONS );
+    ( void ) C_DigestUpdate( hSession, pPart, ulPartlen );
+    xResult = C_DigestUpdate( hSession, NULL, ulPartlen );
+    __CPROVER_assert( xResult == CKR_ARGUMENTS_BAD, "A NULL buffer is considered a bad argument." );
 }

--- a/test/cbmc/proofs/C_DigestUpdate/C_DigestUpdate_harness.c
+++ b/test/cbmc/proofs/C_DigestUpdate/C_DigestUpdate_harness.c
@@ -82,7 +82,10 @@ void harness()
     CK_BYTE_PTR pPart = malloc( ulPartlen );
 
     __CPROVER_assume( hSession >= 1 && hSession <= pkcs11configMAX_SESSIONS );
+    /* There is no return value to check, since we are checking multiple branch paths, and there is no
+     * output to compare the return value to. */
     ( void ) C_DigestUpdate( hSession, pPart, ulPartlen );
+
     xResult = C_DigestUpdate( hSession, NULL, ulPartlen );
     __CPROVER_assert( xResult == CKR_ARGUMENTS_BAD, "A NULL buffer is considered a bad argument." );
 }

--- a/test/cbmc/proofs/C_DigestUpdate/C_DigestUpdate_harness.c
+++ b/test/cbmc/proofs/C_DigestUpdate/C_DigestUpdate_harness.c
@@ -82,6 +82,7 @@ void harness()
     CK_BYTE_PTR pPart = malloc( ulPartlen );
 
     __CPROVER_assume( hSession >= 1 && hSession <= pkcs11configMAX_SESSIONS );
+
     /* There is no return value to check, since we are checking multiple branch paths, and there is no
      * output to compare the return value to. */
     ( void ) C_DigestUpdate( hSession, pPart, ulPartlen );

--- a/test/cbmc/proofs/C_DigestUpdate/C_DigestUpdate_harness.c
+++ b/test/cbmc/proofs/C_DigestUpdate/C_DigestUpdate_harness.c
@@ -89,4 +89,6 @@ void harness()
 
     xResult = C_DigestUpdate( hSession, NULL, ulPartlen );
     __CPROVER_assert( xResult == CKR_ARGUMENTS_BAD, "A NULL buffer is considered a bad argument." );
+
+    free( pPart );
 }

--- a/test/cbmc/proofs/C_DigestUpdate/Makefile
+++ b/test/cbmc/proofs/C_DigestUpdate/Makefile
@@ -1,0 +1,22 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+HARNESS_ENTRY = harness
+HARNESS_FILE = C_DigestUpdate_harness
+
+# This should be a unique identifier for this proof, and will appear on the
+# Litani dashboard. It can be human-readable and contain spaces if you wish.
+PROOF_UID = C_DigestUpdate
+
+DEFINES +=
+INCLUDES += -I$(SRCDIR)/source/dependency/3rdparty/mbedtls/include
+INCLUDES += -I$(SRCDIR)/source/dependency/3rdparty/mbedtls_utils
+
+REMOVE_FUNCTION_BODY +=
+UNWINDSET +=
+
+PROOF_SOURCES += $(PROOFDIR)/$(HARNESS_FILE).c
+PROJECT_SOURCES += $(SRCDIR)/source/portable/mbedtls/core_pkcs11_mbedtls.c
+PROOF_SOURCES += $(SRCDIR)/test/cbmc/stubs/mbedtls_stubs.c
+
+include ../Makefile.common

--- a/test/cbmc/proofs/C_DigestUpdate/README.md
+++ b/test/cbmc/proofs/C_DigestUpdate/README.md
@@ -1,0 +1,20 @@
+C_DigestUpdate proof
+==============
+
+This directory contains a memory safety proof for C_DigestUpdate.
+
+To run the proof.
+-------------
+
+* Add `cbmc`, `goto-cc`, `goto-instrument`, `goto-analyzer`, and `cbmc-viewer`
+  to your path.
+* Run `make`.
+* Open html/index.html in a web browser.
+
+To use [`arpa`](https://github.com/awslabs/aws-proof-build-assistant) to simplify writing Makefiles.
+-------------
+
+* Run `make arpa` to generate a Makefile.arpa that contains relevant build information for the proof.
+* Use Makefile.arpa as the starting point for your proof Makefile by:
+  1. Modifying Makefile.arpa (if required).
+  2. Including Makefile.arpa into the existing proof Makefile (add `sinclude Makefile.arpa` at the bottom of the Makefile, right before `include ../Makefile.common`).

--- a/test/cbmc/proofs/C_DigestUpdate/cbmc-proof.txt
+++ b/test/cbmc/proofs/C_DigestUpdate/cbmc-proof.txt
@@ -1,0 +1,1 @@
+# This file marks this directory as containing a CBMC proof.

--- a/test/cbmc/proofs/C_DigestUpdate/cbmc-viewer.json
+++ b/test/cbmc/proofs/C_DigestUpdate/cbmc-viewer.json
@@ -1,0 +1,7 @@
+{ "expected-missing-functions":
+  [
+
+  ],
+  "proof-name": "C_DigestUpdate",
+  "proof-root": "test/cbmc/proofs"
+}

--- a/test/cbmc/stubs/mbedtls_stubs.c
+++ b/test/cbmc/stubs/mbedtls_stubs.c
@@ -109,21 +109,22 @@ int mbedtls_ecdsa_verify( mbedtls_ecp_group * grp,
     return nondet_bool() ? 0 : -1;
 }
 
-void mbedtls_sha256_init( mbedtls_sha256_context *ctx )
+void mbedtls_sha256_init( mbedtls_sha256_context * ctx )
 {
     __CPROVER_assert( ctx != NULL, "Received an unexpected NULL pointer." );
     return nondet_bool() ? 0 : -1;
 }
 
-int mbedtls_sha256_starts_ret( mbedtls_sha256_context *ctx, int is224 )
+int mbedtls_sha256_starts_ret( mbedtls_sha256_context * ctx,
+                               int is224 )
 {
     __CPROVER_assert( ctx != NULL, "Received an unexpected NULL pointer." );
     __CPROVER_assert( is224 == 0, "We are only doing sha256 currently." );
     return nondet_bool() ? 0 : -1;
 }
 
-int mbedtls_sha256_finish_ret( mbedtls_sha256_context *ctx,
-                               unsigned char output[32] )
+int mbedtls_sha256_finish_ret( mbedtls_sha256_context * ctx,
+                               unsigned char output[ 32 ] )
 {
     __CPROVER_assert( ctx != NULL, "Received an unexpected NULL pointer." );
     __CPROVER_assert( output != NULL, "Received an unexpected NULL pointer." );

--- a/test/cbmc/stubs/mbedtls_stubs.c
+++ b/test/cbmc/stubs/mbedtls_stubs.c
@@ -122,6 +122,16 @@ int mbedtls_sha256_starts_ret( mbedtls_sha256_context *ctx, int is224 )
     return nondet_bool() ? 0 : -1;
 }
 
+int mbedtls_sha256_finish_ret( mbedtls_sha256_context *ctx,
+                               unsigned char output[32] )
+{
+    __CPROVER_assert( ctx != NULL, "Received an unexpected NULL pointer." );
+    __CPROVER_assert( output != NULL, "Received an unexpected NULL pointer." );
+    __CPROVER_assert( __CPROVER_OBJECT_SIZE( output ) == 32UL, "SHA256 output buffers must be 32 bytes." );
+
+    return 32;
+}
+
 int mbedtls_pk_verify( mbedtls_pk_context * ctx,
                        mbedtls_md_type_t md_alg,
                        const unsigned char * hash,

--- a/test/cbmc/stubs/mbedtls_stubs.c
+++ b/test/cbmc/stubs/mbedtls_stubs.c
@@ -109,6 +109,19 @@ int mbedtls_ecdsa_verify( mbedtls_ecp_group * grp,
     return nondet_bool() ? 0 : -1;
 }
 
+void mbedtls_sha256_init( mbedtls_sha256_context *ctx )
+{
+    __CPROVER_assert( ctx != NULL, "Received an unexpected NULL pointer." );
+    return nondet_bool() ? 0 : -1;
+}
+
+int mbedtls_sha256_starts_ret( mbedtls_sha256_context *ctx, int is224 )
+{
+    __CPROVER_assert( ctx != NULL, "Received an unexpected NULL pointer." );
+    __CPROVER_assert( is224 == 0, "We are only doing sha256 currently." );
+    return nondet_bool() ? 0 : -1;
+}
+
 int mbedtls_pk_verify( mbedtls_pk_context * ctx,
                        mbedtls_md_type_t md_alg,
                        const unsigned char * hash,
@@ -121,6 +134,8 @@ int mbedtls_pk_verify( mbedtls_pk_context * ctx,
     __CPROVER_assert( sig != NULL, "Received an unexpected NULL pointer." );
     return nondet_bool() ? 0 : -1;
 }
+
+
 
 static void threading_mutex_init( mbedtls_threading_mutex_t * mutex )
 {

--- a/test/unit-test/core_pkcs11_mbedtls_utest.c
+++ b/test/unit-test/core_pkcs11_mbedtls_utest.c
@@ -1855,7 +1855,7 @@ void test_pkcs11_C_CreateObjectCertificateTooLongLabel( void )
                                   ( CK_ATTRIBUTE_PTR ) &xCertificateTemplate,
                                   sizeof( xCertificateTemplate ) / sizeof( CK_ATTRIBUTE ),
                                   &xObject );
-        TEST_ASSERT_EQUAL( CKR_DATA_LEN_RANGE, xResult );
+        TEST_ASSERT_EQUAL( CKR_BUFFER_TOO_SMALL, xResult );
     }
 
     prvCommonDeinitStubs();
@@ -3293,10 +3293,7 @@ void test_pkcs11_C_SignBadArgs( void )
 
         ulDummySignatureLen = sizeof( pxDummySignature );
         xResult = C_Sign( xSession, pxDummyData, 0, pxDummySignature, &ulDummySignatureLen );
-        TEST_ASSERT_EQUAL( CKR_DATA_LEN_RANGE, xResult );
-
-        xResult = C_SignInit( xSession, &xMechanism, xKey );
-        TEST_ASSERT_EQUAL( CKR_OK, xResult );
+        TEST_ASSERT_EQUAL( CKR_BUFFER_TOO_SMALL, xResult );
 
         ulDummySignatureLen = sizeof( pxDummySignature );
         mock_osal_mutex_lock_Stub( NULL );
@@ -3663,7 +3660,7 @@ void test_pkcs11_C_VerifyBadArgs( void )
         TEST_ASSERT_EQUAL( CKR_OK, xResult );
 
         xResult = C_Verify( xSession, pxDummyData, 0, pxDummySignature, ulDummySignatureLen );
-        TEST_ASSERT_EQUAL( CKR_DATA_LEN_RANGE, xResult );
+        TEST_ASSERT_EQUAL( CKR_BUFFER_TOO_SMALL, xResult );
 
         PKCS11_PAL_GetObjectValue_ExpectAnyArgsAndReturn( CKR_OK );
         PKCS11_PAL_GetObjectValue_ReturnThruPtr_pIsPrivate( &xIsPrivate );
@@ -3715,7 +3712,7 @@ void test_pkcs11_C_VerifyBadArgs( void )
         TEST_ASSERT_EQUAL( CKR_OK, xResult );
 
         xResult = C_Verify( xSession, pxDummyData, 0, pxDummySignature, pkcs11RSA_2048_SIGNATURE_LENGTH );
-        TEST_ASSERT_EQUAL( CKR_DATA_LEN_RANGE, xResult );
+        TEST_ASSERT_EQUAL( CKR_BUFFER_TOO_SMALL, xResult );
 
         PKCS11_PAL_GetObjectValue_ExpectAnyArgsAndReturn( CKR_OK );
         PKCS11_PAL_GetObjectValue_ReturnThruPtr_pIsPrivate( &xIsPrivate );

--- a/test/unit-test/core_pkcs11_mbedtls_utest.c
+++ b/test/unit-test/core_pkcs11_mbedtls_utest.c
@@ -2832,7 +2832,7 @@ void test_pkcs11_C_DigestFinalBadArgs( void )
 
         ulDigestLen = 0;
         xResult = C_DigestFinal( xSession, pxDummyData, &ulDigestLen );
-        TEST_ASSERT_EQUAL( CKR_DATA_LEN_RANGE, xResult );
+        TEST_ASSERT_EQUAL( CKR_BUFFER_TOO_SMALL, xResult );
     }
 
     prvCommonDeinitStubs();

--- a/test/unit-test/core_pkcs11_mbedtls_utest.c
+++ b/test/unit-test/core_pkcs11_mbedtls_utest.c
@@ -2832,7 +2832,7 @@ void test_pkcs11_C_DigestFinalBadArgs( void )
 
         ulDigestLen = 0;
         xResult = C_DigestFinal( xSession, pxDummyData, &ulDigestLen );
-        TEST_ASSERT_EQUAL( CKR_BUFFER_TOO_SMALL, xResult );
+        TEST_ASSERT_EQUAL( CKR_DATA_LEN_RANGE, xResult );
     }
 
     prvCommonDeinitStubs();

--- a/test/unit-test/core_pkcs11_mbedtls_utest.c
+++ b/test/unit-test/core_pkcs11_mbedtls_utest.c
@@ -1855,7 +1855,7 @@ void test_pkcs11_C_CreateObjectCertificateTooLongLabel( void )
                                   ( CK_ATTRIBUTE_PTR ) &xCertificateTemplate,
                                   sizeof( xCertificateTemplate ) / sizeof( CK_ATTRIBUTE ),
                                   &xObject );
-        TEST_ASSERT_EQUAL( CKR_BUFFER_TOO_SMALL, xResult );
+        TEST_ASSERT_EQUAL( CKR_DATA_LEN_RANGE, xResult );
     }
 
     prvCommonDeinitStubs();
@@ -3293,7 +3293,10 @@ void test_pkcs11_C_SignBadArgs( void )
 
         ulDummySignatureLen = sizeof( pxDummySignature );
         xResult = C_Sign( xSession, pxDummyData, 0, pxDummySignature, &ulDummySignatureLen );
-        TEST_ASSERT_EQUAL( CKR_BUFFER_TOO_SMALL, xResult );
+        TEST_ASSERT_EQUAL( CKR_DATA_LEN_RANGE, xResult );
+
+        xResult = C_SignInit( xSession, &xMechanism, xKey );
+        TEST_ASSERT_EQUAL( CKR_OK, xResult );
 
         ulDummySignatureLen = sizeof( pxDummySignature );
         mock_osal_mutex_lock_Stub( NULL );
@@ -3660,7 +3663,7 @@ void test_pkcs11_C_VerifyBadArgs( void )
         TEST_ASSERT_EQUAL( CKR_OK, xResult );
 
         xResult = C_Verify( xSession, pxDummyData, 0, pxDummySignature, ulDummySignatureLen );
-        TEST_ASSERT_EQUAL( CKR_BUFFER_TOO_SMALL, xResult );
+        TEST_ASSERT_EQUAL( CKR_DATA_LEN_RANGE, xResult );
 
         PKCS11_PAL_GetObjectValue_ExpectAnyArgsAndReturn( CKR_OK );
         PKCS11_PAL_GetObjectValue_ReturnThruPtr_pIsPrivate( &xIsPrivate );
@@ -3712,7 +3715,7 @@ void test_pkcs11_C_VerifyBadArgs( void )
         TEST_ASSERT_EQUAL( CKR_OK, xResult );
 
         xResult = C_Verify( xSession, pxDummyData, 0, pxDummySignature, pkcs11RSA_2048_SIGNATURE_LENGTH );
-        TEST_ASSERT_EQUAL( CKR_BUFFER_TOO_SMALL, xResult );
+        TEST_ASSERT_EQUAL( CKR_DATA_LEN_RANGE, xResult );
 
         PKCS11_PAL_GetObjectValue_ExpectAnyArgsAndReturn( CKR_OK );
         PKCS11_PAL_GetObjectValue_ReturnThruPtr_pIsPrivate( &xIsPrivate );


### PR DESCRIPTION
Added CBMC proofs for:
* C_DestroyObject
* C_DigestInit
* C_DigestUpdate
* C_DigestFinal

Added handle value check to C_DestroyObject.
SHA-256 buffer MUST now be 32 bytes, instead of just greater than 32 bytes.
