### PR TITLE
Remove PKCS11_PAL_ObjectDestroy from mbedtls implementation.

### DIFF
--- a/docs/doxygen/include/size_table.html
+++ b/docs/doxygen/include/size_table.html
@@ -19,12 +19,13 @@
     </tr>
     <tr>
         <td>core_pkcs11_mbedtls.c</td>
-        <td><center>7.2K</center></td>
-        <td><center>6.3K</center></td>
+        <td><center>6.9K</center></td>
+        <td><center>5.9K</center></td>
     </tr>
     <tr>
         <td><b>Total estimates</b></td>
-        <td><b><center>8.5K</center></b></td>
-        <td><b><center>7.4K</center></b></td>
+        <td><b><center>8.2K</center></b></td>
+        <td><b><center>7.0K</center></b></td>
     </tr>
 </table>
+

--- a/docs/doxygen/include/size_table.html
+++ b/docs/doxygen/include/size_table.html
@@ -28,4 +28,3 @@
         <td><b><center>7.0K</center></b></td>
     </tr>
 </table>
-

--- a/docs/doxygen/pages.dox
+++ b/docs/doxygen/pages.dox
@@ -389,7 +389,7 @@ The PKCS #11 label for the AWS Trusted Root Certificate.
 @snippet core_pkcs11_pal.h declare_pkcs11_pal_saveobject
 
 @page pkcs11_pal_destroyobject PKCS11_PAL_DestroyObject
-@snippet core_pkcs11_mbedtls.c declare_pkcs11_pal_destroyobject
+@snippet core_pkcs11_pal.h declare_pkcs11_pal_destroyobject
 
 @page pkcs11_pal_findobject PKCS11_PAL_FindObject
 @snippet core_pkcs11_pal.h declare_pkcs11_pal_findobject

--- a/docs/doxygen/pages.dox
+++ b/docs/doxygen/pages.dox
@@ -230,14 +230,6 @@ The more sessions created, the higher RAM used by the PKCS #11 module.<br>
 <b>Possible values:</b> 0 or 1 <br>
 <b>Default value (if undefined): </b> `0`
 
-@section pkcs11configPAL_DESTROY_SUPPORTED
-@brief Set to 1 if a PAL destroy object is implemented.
-
-Set to 1 if a PAL destroy object is implemented. If not implemented PKCS #11 will not be able to destroy existing objects.
-
-<b>Possible values:</b> Any positive integer.<br>
-<b>Default value (if undefined): </b> `0`
-
 @section pkcs11configLABEL_DEVICE_PRIVATE_KEY_FOR_TLS
 @brief The PKCS #11 label for device private key.
 
@@ -421,5 +413,3 @@ The PKCS #11 label for the AWS Trusted Root Certificate.
 @page pkcs11_utils_pkimbedtlssignaturetopkcs11signature PKI_pkcs11SignatureTombedTLSSignature
 @snippet core_pki_utils.h declare_pkcs11_utils_pkimbedtlssignaturetopkcs11signature
 */
-
-

--- a/source/portable/mbedtls/core_pkcs11_mbedtls.c
+++ b/source/portable/mbedtls/core_pkcs11_mbedtls.c
@@ -2583,7 +2583,7 @@ CK_DECLARE_FUNCTION( CK_RV, C_DestroyObject )( CK_SESSION_HANDLE hSession,
         xResult = CKR_OBJECT_HANDLE_INVALID;
     }
 
-    if( ( xResult == CKR_OK ) && ( xPalHandle != CK_INVALID_HANDLE ) )
+    if( xResult == CKR_OK )
     {
         xResult = PKCS11_PAL_DestroyObject( xPalHandle );
         LogDebug( ( "PKCS11_PAL_DestroyObject returned 0x%0lX", ( unsigned long int ) xResult ) );
@@ -3107,8 +3107,6 @@ CK_DECLARE_FUNCTION( CK_RV, C_FindObjects )( CK_SESSION_HANDLE hSession,
 
     /* See explanation in prvCheckValidSessionAndModule for this exception. */
     /* coverity[misra_c_2012_rule_10_5_violation] */
-    CK_BBOOL xIsPrivate = ( CK_BBOOL ) CK_TRUE;
-    CK_BYTE xByte = 0;
     CK_OBJECT_HANDLE xPalHandle = CK_INVALID_HANDLE;
 
     /*

--- a/source/portable/mbedtls/core_pkcs11_mbedtls.c
+++ b/source/portable/mbedtls/core_pkcs11_mbedtls.c
@@ -4726,13 +4726,16 @@ CK_DECLARE_FUNCTION( CK_RV, C_GenerateKeyPair )( CK_SESSION_HANDLE hSession,
 
             if( xResult != CKR_OK )
             {
-                ( void ) PKCS11_PAL_DestroyObject( *phPrivateKey );
-                LogDebug( ( "Destroyed %lu private key handle due to errors.", ( unsigned long int ) *phPrivateKey ) );
+                ( void ) PKCS11_PAL_DestroyObject( xPalPrivate );
+                ( void ) PKCS11_PAL_DestroyObject( xPalPublic );
+                LogError( ( "Could not add private key to object list. Cleaning up PAL objects." ) );
             }
         }
         else
         {
-            LogDebug( ( "Could not add private key to object list." ) );
+            ( void ) PKCS11_PAL_DestroyObject( xPalPrivate );
+            ( void ) PKCS11_PAL_DestroyObject( xPalPublic );
+            LogError( ( "Could not add private key to object list. Cleaning up PAL objects." ) );
         }
     }
 

--- a/source/portable/mbedtls/core_pkcs11_mbedtls.c
+++ b/source/portable/mbedtls/core_pkcs11_mbedtls.c
@@ -1083,21 +1083,26 @@ static void prvFindObjectInListByHandle( CK_OBJECT_HANDLE xAppHandle,
  *
  * @warning This does not delete the object from NVM.
  *
- * @param[in] xAppHandle     Application handle of the object to be deleted.
+ * @param[in] xPalHandle            PAL handle of the object to be deleted.
  */
-static CK_RV prvDeleteObjectFromList( CK_OBJECT_HANDLE xAppHandle )
+static CK_RV prvDeleteObjectFromList( CK_OBJECT_HANDLE xPalHandle )
 {
     CK_RV xResult = CKR_OK;
     int32_t lGotSemaphore = ( int32_t ) 0;
-    CK_OBJECT_HANDLE ulIndex = xAppHandle - ( ( CK_OBJECT_HANDLE ) 1 );
+    uint32_t ulIndex = 0;
 
     lGotSemaphore = mbedtls_mutex_lock( &xP11Context.xObjectList.xMutex );
 
     if( lGotSemaphore == 0 )
     {
-        if( xP11Context.xObjectList.xObjects[ ulIndex ].xHandle != CK_INVALID_HANDLE )
+        /* Remove all references that have the same PAL handle, as it has now
+         * been deleted in the PKCS11_PAL. */
+        for( ulIndex = 0; ulIndex < pkcs11configMAX_NUM_OBJECTS; ulIndex++ )
         {
-            ( void ) memset( &xP11Context.xObjectList.xObjects[ ulIndex ], 0, sizeof( P11Object_t ) );
+            if( xP11Context.xObjectList.xObjects[ ulIndex ].xHandle == xPalHandle )
+            {
+                ( void ) memset( &xP11Context.xObjectList.xObjects[ ulIndex ], 0, sizeof( P11Object_t ) );
+            }
         }
 
         ( void ) mbedtls_mutex_unlock( &xP11Context.xObjectList.xMutex );
@@ -1111,7 +1116,6 @@ static CK_RV prvDeleteObjectFromList( CK_OBJECT_HANDLE xAppHandle )
 
     return xResult;
 }
-
 
 /**
  * @brief Add an object that exists in NVM to the application object array.
@@ -1333,123 +1337,6 @@ static CK_RV prvSaveDerKeyToPal( mbedtls_pk_context * pxMbedContext,
 
     return xResult;
 }
-
-
-#if ( pkcs11configPAL_DESTROY_SUPPORTED != 1 )
-
-/**
- * @brief Given a label delete the corresponding private or public key.
- */
-    static CK_RV prvOverwritePalObject( CK_OBJECT_HANDLE xPalHandle,
-                                        CK_ATTRIBUTE_PTR pxLabel )
-    {
-        /* See explanation in prvCheckValidSessionAndModule for this exception. */
-        /* coverity[misra_c_2012_rule_10_5_violation] */
-        CK_BBOOL xIsPrivate = ( CK_BBOOL ) CK_TRUE;
-        CK_RV xResult = CKR_OK;
-        CK_BYTE_PTR pxZeroedData = NULL;
-        CK_BYTE_PTR pxObject = NULL;
-        CK_ULONG ulObjectLength = sizeof( CK_BYTE ); /* MISRA: Cannot initialize to 0, as the integer passed to memset must be positive. */
-        CK_OBJECT_HANDLE xPalHandle2 = CK_INVALID_HANDLE;
-
-        xResult = PKCS11_PAL_GetObjectValue( xPalHandle, &pxObject, &ulObjectLength, &xIsPrivate );
-
-        if( xResult == CKR_OK )
-        {
-            /* Some ports return a pointer to memory for which using memset directly won't work. */
-            pxZeroedData = mbedtls_calloc( 1, ulObjectLength );
-
-            if( NULL != pxZeroedData )
-            {
-                /* Zero out the object. */
-                ( void ) memset( pxZeroedData, 0x0, ulObjectLength );
-                /* Create an object label attribute. */
-                /* Overwrite the object in NVM with zeros. */
-                xPalHandle2 = PKCS11_PAL_SaveObject( pxLabel, pxZeroedData, ( size_t ) ulObjectLength );
-
-                if( xPalHandle2 != xPalHandle )
-                {
-                    LogError( ( "Failed destroying object. Received a "
-                                "different handle from the PAL when writing "
-                                "to the same label." ) );
-                    xResult = CKR_GENERAL_ERROR;
-                }
-            }
-            else
-            {
-                LogError( ( "Failed destroying object. Failed to allocated "
-                            "a buffer of length %lu bytes.", ulObjectLength ) );
-                xResult = CKR_HOST_MEMORY;
-            }
-
-            PKCS11_PAL_GetObjectValueCleanup( pxObject, ulObjectLength );
-            mbedtls_free( pxZeroedData );
-        }
-
-        return xResult;
-    }
-
-/* @[declare_pkcs11_pal_destroyobject] */
-    CK_RV PKCS11_PAL_DestroyObject( CK_OBJECT_HANDLE xHandle )
-    {
-        CK_BYTE_PTR pcLabel = NULL;
-        CK_ULONG xLabelLength = 0;
-        CK_RV xResult = CKR_OK;
-        CK_ATTRIBUTE xLabel = { 0 };
-        CK_OBJECT_HANDLE xPalHandle = CK_INVALID_HANDLE;
-        CK_OBJECT_HANDLE xAppHandle2 = CK_INVALID_HANDLE;
-        CK_BYTE pxPubKeyLabel[] = { pkcs11configLABEL_DEVICE_PUBLIC_KEY_FOR_TLS };
-        CK_BYTE pxPrivKeyLabel[] = { pkcs11configLABEL_DEVICE_PRIVATE_KEY_FOR_TLS };
-
-        prvFindObjectInListByHandle( xHandle, &xPalHandle, &pcLabel, &xLabelLength );
-
-        if( pcLabel != NULL )
-        {
-            xLabel.type = CKA_LABEL;
-            xLabel.pValue = pcLabel;
-            xLabel.ulValueLen = xLabelLength;
-            xResult = prvOverwritePalObject( xPalHandle, &xLabel );
-        }
-        else
-        {
-            LogError( ( "Failed destroying object. Could not found the object label." ) );
-            xResult = CKR_ATTRIBUTE_VALUE_INVALID;
-        }
-
-        if( xResult == CKR_OK )
-        {
-            if( 0 == strncmp( xLabel.pValue, pkcs11configLABEL_DEVICE_PRIVATE_KEY_FOR_TLS, xLabel.ulValueLen ) )
-            {
-                /* Remove NULL terminator in comparison. */
-                prvFindObjectInListByLabel( pxPubKeyLabel, sizeof( pkcs11configLABEL_DEVICE_PUBLIC_KEY_FOR_TLS ), &xPalHandle, &xAppHandle2 );
-            }
-            else if( 0 == strncmp( xLabel.pValue, pkcs11configLABEL_DEVICE_PUBLIC_KEY_FOR_TLS, xLabel.ulValueLen ) )
-            {
-                /* Remove NULL terminator in comparison. */
-                prvFindObjectInListByLabel( pxPrivKeyLabel, sizeof( pkcs11configLABEL_DEVICE_PRIVATE_KEY_FOR_TLS ), &xPalHandle, &xAppHandle2 );
-            }
-            else
-            {
-                LogWarn( ( "Trying to destroy an object with an unknown label." ) );
-            }
-
-            if( ( xPalHandle != CK_INVALID_HANDLE ) && ( xAppHandle2 != CK_INVALID_HANDLE ) )
-            {
-                xResult = prvDeleteObjectFromList( xAppHandle2 );
-            }
-
-            if( xResult != CKR_OK )
-            {
-                LogWarn( ( "Failed to remove xAppHandle2 from object list when destroying object memory." ) );
-            }
-
-            xResult = prvDeleteObjectFromList( xHandle );
-        }
-
-        return xResult;
-    }
-    /* @[declare_pkcs11_pal_destroyobject] */
-#endif /* if ( pkcs11configPAL_DESTROY_SUPPORTED != 1 ) */
 
 /*-------------------------------------------------------------*/
 
@@ -2680,20 +2567,39 @@ CK_DECLARE_FUNCTION( CK_RV, C_DestroyObject )( CK_SESSION_HANDLE hSession,
 {
     const P11Session_t * pxSession = prvSessionPointerFromHandle( hSession );
     CK_RV xResult = prvCheckValidSessionAndModule( pxSession );
+    CK_OBJECT_HANDLE xPalHandle = CK_INVALID_HANDLE;
+    CK_BYTE_PTR pcLabel = NULL;
+    CK_ULONG xLabelLength = 0;
+
+    prvFindObjectInListByHandle( hObject, &xPalHandle, &pcLabel, &xLabelLength );
 
     if( ( hObject < 1UL ) || ( hObject > pkcs11configMAX_NUM_OBJECTS ) )
     {
         xResult = CKR_OBJECT_HANDLE_INVALID;
     }
 
-    if( xResult == CKR_OK )
+    if( xPalHandle == CK_INVALID_HANDLE )
     {
-        xResult = PKCS11_PAL_DestroyObject( hObject );
+        xResult = CKR_OBJECT_HANDLE_INVALID;
+    }
+
+    if( ( xResult == CKR_OK ) && ( xPalHandle != CK_INVALID_HANDLE ) )
+    {
+        xResult = PKCS11_PAL_DestroyObject( xPalHandle );
         LogDebug( ( "PKCS11_PAL_DestroyObject returned 0x%0lX", ( unsigned long int ) xResult ) );
     }
     else
     {
         LogError( ( "Failed to destroy object. The session was invalid." ) );
+    }
+
+    if( xResult == CKR_OK )
+    {
+        xResult = prvDeleteObjectFromList( xPalHandle );
+    }
+    else
+    {
+        LogError( ( "Failed to destroy object. PKCS11_PAL_DestroyObject failed." ) );
     }
 
     return xResult;
@@ -3199,14 +3105,11 @@ CK_DECLARE_FUNCTION( CK_RV, C_FindObjects )( CK_SESSION_HANDLE hSession,
     P11Session_t * pxSession = prvSessionPointerFromHandle( hSession );
     CK_RV xResult = prvCheckValidSessionAndModule( pxSession );
 
-    CK_BYTE_PTR pucObjectValue = NULL;
-    CK_ULONG xObjectLength = 0;
     /* See explanation in prvCheckValidSessionAndModule for this exception. */
     /* coverity[misra_c_2012_rule_10_5_violation] */
     CK_BBOOL xIsPrivate = ( CK_BBOOL ) CK_TRUE;
     CK_BYTE xByte = 0;
     CK_OBJECT_HANDLE xPalHandle = CK_INVALID_HANDLE;
-    CK_ULONG ulIndex;
 
     /*
      * Check parameters.
@@ -3251,34 +3154,9 @@ CK_DECLARE_FUNCTION( CK_RV, C_FindObjects )( CK_SESSION_HANDLE hSession,
 
         if( xPalHandle != CK_INVALID_HANDLE )
         {
-            xResult = PKCS11_PAL_GetObjectValue( xPalHandle, &pucObjectValue, &xObjectLength, &xIsPrivate );
-
-            if( xResult == CKR_OK )
-            {
-                for( ulIndex = 0; ulIndex < xObjectLength; ulIndex++ )
-                {
-                    xByte = pucObjectValue[ ulIndex ];
-
-                    if( xByte != 0UL )
-                    {
-                        break;
-                    }
-                }
-
-                if( xByte == 0UL ) /* Deleted objects are overwritten completely w/ zero. */
-                {
-                    LogDebug( ( "Found an overwritten object." ) );
-                    *phObject = CK_INVALID_HANDLE;
-                }
-                else
-                {
-                    LogDebug( ( "Found object in PAL. Adding object handle to list." ) );
-                    xResult = prvAddObjectToList( xPalHandle, phObject, pxSession->pxFindObjectLabel, pxSession->xFindObjectLabelLen );
-                    *pulObjectCount = 1;
-                }
-
-                PKCS11_PAL_GetObjectValueCleanup( pucObjectValue, xObjectLength );
-            }
+            LogDebug( ( "Found object in PAL. Adding object handle to list." ) );
+            xResult = prvAddObjectToList( xPalHandle, phObject, pxSession->pxFindObjectLabel, pxSession->xFindObjectLabelLen );
+            *pulObjectCount = 1;
         }
         else
         {
@@ -3301,6 +3179,7 @@ CK_DECLARE_FUNCTION( CK_RV, C_FindObjects )( CK_SESSION_HANDLE hSession,
 
     return xResult;
 }
+
 /* @[declare_pkcs11_mbedtls_c_findobjects] */
 
 /**

--- a/source/portable/posix/core_pkcs11_pal.c
+++ b/source/portable/posix/core_pkcs11_pal.c
@@ -71,7 +71,7 @@ enum eObjectHandles
  *
  * @param[in] pcFileName         The name of the file to check for existance.
  *
- * @returns pdTRUE if the file exists, pdFALSE if not.
+ * @returns CKR_OK if the file exists, CKR_OBJECT_HANDLE_INVALID if not.
  */
 static CK_RV prvFileExists( const char * pcFileName )
 {
@@ -413,6 +413,38 @@ void PKCS11_PAL_GetObjectValueCleanup( CK_BYTE_PTR pucData,
     {
         free( pucData );
     }
+}
+
+/*-----------------------------------------------------------*/
+
+CK_RV PKCS11_PAL_DestroyObject( CK_OBJECT_HANDLE xHandle )
+{
+    const char * pcFileName = NULL;
+    CK_BBOOL xIsPrivate = CK_TRUE;
+    CK_RV xResult = CKR_OK;
+    FILE * pxFile = NULL;
+    int ret = 0;
+
+
+    xResult = prvHandleToFilename( xHandle,
+                                   &pcFileName,
+                                   &xIsPrivate );
+
+    if( ( xResult == CKR_OK ) && ( prvFileExists( pcFileName ) == CKR_OK ) )
+    {
+        ret = remove( pcFileName );
+    }
+    else
+    {
+        xResult = CKR_OBJECT_HANDLE_INVALID;
+    }
+
+    if( ret != 0 )
+    {
+        xResult = CKR_FUNCTION_FAILED;
+    }
+
+    return xResult;
 }
 
 /*-----------------------------------------------------------*/

--- a/source/portable/posix/core_pkcs11_pal.c
+++ b/source/portable/posix/core_pkcs11_pal.c
@@ -421,7 +421,7 @@ CK_RV PKCS11_PAL_DestroyObject( CK_OBJECT_HANDLE xHandle )
 {
     const char * pcFileName = NULL;
     CK_BBOOL xIsPrivate = CK_TRUE;
-    CK_RV xResult = CKR_OK;
+    CK_RV xResult = CKR_OBJECT_HANDLE_INVALID;
     FILE * pxFile = NULL;
     int ret = 0;
 
@@ -433,15 +433,11 @@ CK_RV PKCS11_PAL_DestroyObject( CK_OBJECT_HANDLE xHandle )
     if( ( xResult == CKR_OK ) && ( prvFileExists( pcFileName ) == CKR_OK ) )
     {
         ret = remove( pcFileName );
-    }
-    else
-    {
-        xResult = CKR_OBJECT_HANDLE_INVALID;
-    }
 
-    if( ret != 0 )
-    {
-        xResult = CKR_FUNCTION_FAILED;
+        if( ret != 0 )
+        {
+            xResult = CKR_FUNCTION_FAILED;
+        }
     }
 
     return xResult;

--- a/source/portable/windows/core_pkcs11_pal.c
+++ b/source/portable/windows/core_pkcs11_pal.c
@@ -298,7 +298,7 @@ CK_RV PKCS11_PAL_GetObjectValue( CK_OBJECT_HANDLE xHandle,
                                  CK_ULONG_PTR pulDataSize,
                                  CK_BBOOL * pIsPrivate )
 {
-    CK_RV ulReturn = CKR_OK;
+    CK_RV ulReturn = CKR_KEY_HANDLE_INVALID;
     uint32_t ulDriverReturn = 0;
     HANDLE hFile = INVALID_HANDLE_VALUE;
     uint32_t ulSize = 0;
@@ -358,6 +358,8 @@ CK_RV PKCS11_PAL_GetObjectValue( CK_OBJECT_HANDLE xHandle,
         /* Confirm the amount of data read. */
         if( 0 == ulReturn )
         {
+            ulReturn = CKR_OK;
+
             if( ulSize != *pulDataSize )
             {
                 ulReturn = CKR_FUNCTION_FAILED;
@@ -369,10 +371,6 @@ CK_RV PKCS11_PAL_GetObjectValue( CK_OBJECT_HANDLE xHandle,
         {
             CloseHandle( hFile );
         }
-    }
-    else
-    {
-        ulReturn = CKR_KEY_HANDLE_INVALID;
     }
 
     return ulReturn;
@@ -398,10 +396,9 @@ CK_RV PKCS11_PAL_DestroyObject( CK_OBJECT_HANDLE xHandle )
 {
     const char * pcFileName = NULL;
     CK_BBOOL xIsPrivate = CK_TRUE;
-    CK_RV xResult = CKR_OK;
+    CK_RV xResult = CKR_OBJECT_HANDLE_INVALID;
     FILE * pxFile = NULL;
     BOOL ret = 0;
-
 
     xResult = prvHandleToFilename( xHandle,
                                    &pcFileName,
@@ -417,10 +414,10 @@ CK_RV PKCS11_PAL_DestroyObject( CK_OBJECT_HANDLE xHandle )
             {
                 xResult = CKR_FUNCTION_FAILED;
             }
-        }
-        else
-        {
-            xResult = CKR_OBJECT_HANDLE_INVALID;
+            else
+            {
+                xResult = CKR_OK;
+            }
         }
     }
 

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required ( VERSION 3.13.0 )
 project ( "corePKCS11 unit test"
-          VERSION 2.0.0
+          VERSION 3.0.0
           LANGUAGES C )
 
 # Allow the project to be organized into folders.
@@ -93,4 +93,3 @@ add_custom_target( coverage
     DEPENDS cmock unity core_pkcs11_mbedtls_utest core_pkcs11_utest core_pki_utils_utest
     WORKING_DIRECTORY ${CMAKE_BINARY_DIR}
 )
-

--- a/test/cbmc/include/core_pkcs11_config.h
+++ b/test/cbmc/include/core_pkcs11_config.h
@@ -92,14 +92,6 @@
 #define pkcs11configMAX_SESSIONS                           2
 
 /**
- * @brief Set to 1 if a PAL destroy object is implemented.
- *
- * If set to 0, no PAL destroy object is implemented, and this functionality
- * is implemented in the common PKCS #11 layer.
- */
-#define pkcs11configPAL_DESTROY_SUPPORTED                  0
-
-/**
  * @brief Set to 1 if OTA image verification via PKCS #11 module is supported.
  *
  * If set to 0, OTA code signing certificate is built in via

--- a/test/cbmc/proofs/C_DestroyObject/Makefile
+++ b/test/cbmc/proofs/C_DestroyObject/Makefile
@@ -27,6 +27,7 @@ UNWINDSET += strncmp.0:$(MAX_LABEL_SIZE)
 UNWINDSET += strlen.0:$(MAX_LABEL_SIZE)
 
 UNWINDSET += __CPROVER_file_local_core_pkcs11_mbedtls_c_prvFindObjectInListByLabel.0:$(MAX_OBJECT_NUM)
+UNWINDSET += __CPROVER_file_local_core_pkcs11_mbedtls_c_prvDeleteObjectFromList.0:$(MAX_OBJECT_NUM)
 
 
 PROOF_SOURCES += $(PROOFDIR)/$(HARNESS_FILE).c

--- a/test/cbmc/proofs/C_GenerateKeyPair/Makefile
+++ b/test/cbmc/proofs/C_GenerateKeyPair/Makefile
@@ -34,6 +34,7 @@ UNWINDSET += memcpy.0:32
 # Be very careful increasing this. At the time of writing this, the PKCS stack was
 # configured to store just one object.
 UNWINDSET += __CPROVER_file_local_core_pkcs11_mbedtls_c_prvAddObjectToList.0:2
+UNWINDSET += __CPROVER_file_local_core_pkcs11_mbedtls_c_prvDeleteObjectFromList.0:2
 UNWINDSET += C_GenerateKeyPair.0:$(TEMPLATE_SIZE)
 UNWINDSET += C_GenerateKeyPair.1:$(TEMPLATE_SIZE)
 

--- a/test/cbmc/stubs/core_pkcs11_pal_stubs.c
+++ b/test/cbmc/stubs/core_pkcs11_pal_stubs.c
@@ -37,6 +37,16 @@ CK_RV PKCS11_PAL_Initialize( void )
     return xResult;
 }
 
+CK_RV PKCS11_PAL_DestroyObject( CK_OBJECT_HANDLE xHandle )
+{
+    CK_RV xResult;
+
+    __CPROVER_assert( xHandle != CK_INVALID_HANDLE,
+                      "Pal destroy should not get an invalid handle." );
+
+    return xResult;
+}
+
 CK_RV PKCS11_PAL_GetObjectValue( CK_OBJECT_HANDLE xHandle,
                                  CK_BYTE_PTR * ppucData,
                                  CK_ULONG_PTR pulDataSize,

--- a/test/unit-test/config/core_pkcs11_config.h
+++ b/test/unit-test/config/core_pkcs11_config.h
@@ -96,14 +96,6 @@
 #define pkcs11configMAX_SESSIONS                           ( ( CK_ULONG ) 10 )
 
 /**
- * @brief Set to 1 if a PAL destroy object is implemented.
- *
- * If set to 0, no PAL destroy object is implemented, and this functionality
- * is implemented in the common PKCS #11 layer.
- */
-#define pkcs11configPAL_DESTROY_SUPPORTED                  0
-
-/**
  * @brief Set to 1 if OTA image verification via PKCS #11 module is supported.
  *
  * If set to 0, OTA code signing certificate is built in via


### PR DESCRIPTION
Update unit tests.
Provide a PKCS11_PAL_ObjectDestroy implementation for windows and posix.

This change does mean that ports will need to implement this function, and it is no longer optional.