### PR TITLE
Add PR check for doxygen size table

### DIFF
--- a/.github/memory_statistics_config.json
+++ b/.github/memory_statistics_config.json
@@ -1,0 +1,15 @@
+{
+    "lib_name": "corePKCS11",
+    "src": [
+        "source/core_pkcs11.c",
+        "source/core_pki_utils.c",
+        "source/portable/mbedtls/core_pkcs11_mbedtls.c"
+    ],
+    "include": [
+        "source/include",
+        "source/dependency/3rdparty/pkcs11",
+        "source/dependency/3rdparty/mbedtls/include",
+        "source/dependency/3rdparty/mbedtls_utils",
+        "test/unit-test/config"
+    ]
+}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -138,3 +138,13 @@ jobs:
         run: |
           git-secrets --register-aws
           git-secrets --scan
+  memory_statistics:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - run: git submodule update --init --recursive --checkout
+      - name: Measure sizes
+        uses: FreeRTOS/CI-CD-Github-Actions/memory_statistics@main
+        with:
+            config: .github/memory_statistics_config.json
+            check_against: docs/doxygen/include/size_table.html

--- a/.github/workflows/memory_statistics.yml
+++ b/.github/workflows/memory_statistics.yml
@@ -1,0 +1,22 @@
+name: Memory statistics
+
+on:
+  workflow_dispatch:
+
+jobs:
+  memory_statistics:
+    name: Calculate object sizes
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Fix submodules
+        run: git submodule update --init --recursive --checkout
+      - name: Measure sizes
+        uses: FreeRTOS/CI-CD-Github-Actions/memory_statistics@main
+        with:
+            config: .github/memory_statistics_config.json
+      - name: Upload table
+        uses: actions/upload-artifact@v2
+        with:
+          name: size_table
+          path: size_table.html

--- a/docs/doxygen/config.doxyfile
+++ b/docs/doxygen/config.doxyfile
@@ -925,7 +925,8 @@ EXCLUDE_SYMBOLS        =
 
 EXAMPLE_PATH           = source/include \
                          source/portable/mbedtls \
-                         source
+                         source \
+                         docs/doxygen/include
 
 # If the value of the EXAMPLE_PATH tag contains directories, you can use the
 # EXAMPLE_PATTERNS tag to specify one or more wildcard pattern (like *.cpp and

--- a/docs/doxygen/include/size_table.html
+++ b/docs/doxygen/include/size_table.html
@@ -1,0 +1,30 @@
+<table>
+    <tr>
+        <td colspan="3"><center><b>Code Size of corePKCS11 (example generated with GCC for ARM Cortex-M)</b></center></td>
+    </tr>
+    <tr>
+        <td><b>File</b></td>
+        <td><b><center>With -O1 Optimization</center></b></td>
+        <td><b><center>With -Os Optimization</center></b></td>
+    </tr>
+    <tr>
+        <td>core_pkcs11.c</td>
+        <td><center>0.8K</center></td>
+        <td><center>0.8K</center></td>
+    </tr>
+    <tr>
+        <td>core_pki_utils.c</td>
+        <td><center>0.5K</center></td>
+        <td><center>0.3K</center></td>
+    </tr>
+    <tr>
+        <td>core_pkcs11_mbedtls.c</td>
+        <td><center>7.2K</center></td>
+        <td><center>6.3K</center></td>
+    </tr>
+    <tr>
+        <td><b>Total estimates</b></td>
+        <td><b><center>8.5K</center></b></td>
+        <td><b><center>7.4K</center></b></td>
+    </tr>
+</table>

--- a/docs/doxygen/pages.dox
+++ b/docs/doxygen/pages.dox
@@ -18,36 +18,7 @@ This PKCS #11 library implements a subset of the PKCS #11 API required to establ
 @section pkcs11_memory_requirements Memory Requirements
 @brief Memory requirements of the PKCS #11 library.
 
-<table>
-    <tr>
-        <td colspan="3"><center><b>Code Size of corePKCS11  (example generated with GCC for ARM Cortex-M)</b></center></td>
-    </tr>
-    <tr>
-        <td><b>File</b></td>
-        <td><b><center>With -O1 Optimization</center></b></td>
-        <td><b><center>With -Os Optimization</center></b></td>
-    </tr>
-    <tr>
-        <td>core_pkcs11.c</td>
-        <td><center>0.8K</center></td>
-        <td><center>0.8K</center></td>
-    </tr>
-    <tr>
-        <td>core_pki_utils.c</td>
-        <td><center>0.5K</center></td>
-        <td><center>0.3K</center></td>
-    </tr>
-    <tr>
-        <td>core_pkcs11_mbedtls.c</td>
-        <td><center>7.2K</center></td>
-        <td><center>6.3K</center></td>
-    </tr>
-    <tr>
-        <td><b>Total estimates</b></td>
-        <td><b><center>8.5K</center></b></td>
-        <td><b><center>7.4K</center></b></td>
-    </tr>
-</table>
+@include{doc} size_table.html
 */
 
 /**


### PR DESCRIPTION
Adds a PR check using the memory statistics action from the shared actions repo. 
Also adds a manual workflow for generating size tables. 