### PR TITLE
Feature: Import SHA256-HMAC secret Key

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ corePKCS11 is implemented on PKCS #11 v2.4.0, the full PKCS #11 standard can be 
 
 This library has gone through code quality checks including verification that no function has a [GNU Complexity](https://www.gnu.org/software/complexity/manual/complexity.html) score over 8, and checks against deviations from mandatory rules in the [MISRA coding standard](https://www.misra.org.uk/MISRAHome/MISRAC2012/tabid/196/Default.aspx).  Deviations from the MISRA C:2012 guidelines are documented under [MISRA Deviations](MISRA.md). This library has also undergone both static code analysis from [Coverity static analysis](https://scan.coverity.com/) and validation of memory safety and proof of functional correctness through the [CBMC automated reasoning tool](https://www.cprover.org/cbmc/).
 
-See memory requirements for the latest release [here](https://docs.aws.amazon.com/embedded-csdk/202103.00/lib-ref/libraries/standard/corePKCS11/docs/doxygen/output/html/pkcs11_design.html#pkcs11_memory_requirements).
+See memory requirements for the latest release [here](https://docs.aws.amazon.com/embedded-csdk/202012.00/lib-ref/libraries/standard/corePKCS11/docs/doxygen/output/html/pkcs11_design.html#pkcs11_memory_requirements).
 
 **corePKCS11 v3.0.0 [source code](https://github.com/FreeRTOS/corePKCS11/tree/v3.0.0/source) is part of the [FreeRTOS 202012.00 LTS](https://github.com/FreeRTOS/FreeRTOS-LTS/tree/202012.00-LTS) release.**
 

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ corePKCS11 is implemented on PKCS #11 v2.4.0, the full PKCS #11 standard can be 
 
 This library has gone through code quality checks including verification that no function has a [GNU Complexity](https://www.gnu.org/software/complexity/manual/complexity.html) score over 8, and checks against deviations from mandatory rules in the [MISRA coding standard](https://www.misra.org.uk/MISRAHome/MISRAC2012/tabid/196/Default.aspx).  Deviations from the MISRA C:2012 guidelines are documented under [MISRA Deviations](MISRA.md). This library has also undergone both static code analysis from [Coverity static analysis](https://scan.coverity.com/) and validation of memory safety and proof of functional correctness through the [CBMC automated reasoning tool](https://www.cprover.org/cbmc/).
 
-See memory requirements for the latest release [here](https://docs.aws.amazon.com/embedded-csdk/202012.00/lib-ref/libraries/standard/corePKCS11/docs/doxygen/output/html/pkcs11_design.html#pkcs11_memory_requirements).
+See memory requirements for the latest release [here](https://docs.aws.amazon.com/embedded-csdk/202103.00/lib-ref/libraries/standard/corePKCS11/docs/doxygen/output/html/pkcs11_design.html#pkcs11_memory_requirements).
 
 **corePKCS11 v3.0.0 [source code](https://github.com/FreeRTOS/corePKCS11/tree/v3.0.0/source) is part of the [FreeRTOS 202012.00 LTS](https://github.com/FreeRTOS/FreeRTOS-LTS/tree/202012.00-LTS) release.**
 

--- a/docs/doxygen/include/size_table.html
+++ b/docs/doxygen/include/size_table.html
@@ -19,12 +19,12 @@
     </tr>
     <tr>
         <td>core_pkcs11_mbedtls.c</td>
-        <td><center>7.1K</center></td>
-        <td><center>6.2K</center></td>
+        <td><center>7.4K</center></td>
+        <td><center>6.3K</center></td>
     </tr>
     <tr>
         <td><b>Total estimates</b></td>
-        <td><b><center>8.4K</center></b></td>
-        <td><b><center>7.3K</center></b></td>
+        <td><b><center>8.7K</center></b></td>
+        <td><b><center>7.4K</center></b></td>
     </tr>
 </table>

--- a/docs/doxygen/pages.dox
+++ b/docs/doxygen/pages.dox
@@ -233,6 +233,14 @@ The PKCS #11 label for the AWS Trusted Root Certificate.
 
 <b>Possible values:</b> Any String smaller then pkcs11configMAX_LABEL_LENGTH.<br>
 <b>Default value (if undefined): </b> `Root Cert`
+
+@section pkcs11configLABEL_HMAC_KEY
+@brief The PKCS #11 label for the AWS Trusted Root Certificate.
+
+The PKCS #11 label for the object to be used for HMAC operations.
+
+<b>Possible values:</b> Any String smaller then pkcs11configMAX_LABEL_LENGTH.<br>
+<b>Default value (if undefined): </b> `HMAC Key`
 */
 
 /**

--- a/lexicon.txt
+++ b/lexicon.txt
@@ -65,6 +65,7 @@ eawscodesigningkey
 eawsdevicecertificate
 eawsdeviceprivatekey
 eawsdevicepublickey
+eawshmacsecretkey
 ec
 ecdsa
 einvalidhandle
@@ -106,6 +107,7 @@ gettokeninfo
 github
 helvetica
 hkey
+hmac
 hobject
 href
 hsession
@@ -310,6 +312,8 @@ xfindobjectlabellen
 xfindobjectwithlabelandclass
 xgetslotlist
 xhandle
+xhmackeyhandle
+xhmacsecretcontext
 xinitializepkcs
 xisinitialized
 xisprivate

--- a/source/portable/posix/core_pkcs11_pal.c
+++ b/source/portable/posix/core_pkcs11_pal.c
@@ -203,7 +203,7 @@ static CK_RV prvHandleToFilename( CK_OBJECT_HANDLE xHandle,
                 *pIsPrivate = ( CK_BBOOL ) CK_FALSE;
                 break;
 
-            case  eAwsHMACSecretKey:
+            case eAwsHMACSecretKey:
                 *pcFileName = pkcs11palFILE_HMAC_SECRET_KEY;
                 /* coverity[misra_c_2012_rule_10_5_violation] */
                 *pIsPrivate = ( CK_BBOOL ) CK_TRUE;

--- a/source/portable/posix/core_pkcs11_pal.c
+++ b/source/portable/posix/core_pkcs11_pal.c
@@ -48,7 +48,9 @@
  */
 #define pkcs11palFILE_NAME_CLIENT_CERTIFICATE    "FreeRTOS_P11_Certificate.dat"       /**< The file name of the Certificate object. */
 #define pkcs11palFILE_NAME_KEY                   "FreeRTOS_P11_Key.dat"               /**< The file name of the Key object. */
+#define pkcs11palFILE_NAME_PUBLIC_KEY            "FreeRTOS_P11_PubKey.dat"            /**< The file name of the Public Key object. */
 #define pkcs11palFILE_CODE_SIGN_PUBLIC_KEY       "FreeRTOS_P11_CodeSignKey.dat"       /**< The file name of the Code Sign Key object. */
+#define pkcs11palFILE_HMAC_SECRET_KEY            "FreeRTOS_P11_HMACKey.dat"           /**< The file name of the HMAC Secret Key object. */
 
 /**
  * @ingroup pkcs11_enums
@@ -61,7 +63,8 @@ enum eObjectHandles
     eAwsDevicePrivateKey = 1, /**< Private Key. */
     eAwsDevicePublicKey,      /**< Public Key. */
     eAwsDeviceCertificate,    /**< Certificate. */
-    eAwsCodeSigningKey        /**< Code Signing Key. */
+    eAwsCodeSigningKey,       /**< Code Signing Key. */
+    eAwsHMACSecretKey         /**< HMAC Secret Key. */
 };
 
 /*-----------------------------------------------------------*/
@@ -127,7 +130,7 @@ static void prvLabelToFilenameHandle( const char * pcLabel,
                                pcLabel,
                                sizeof( pkcs11configLABEL_DEVICE_PUBLIC_KEY_FOR_TLS ) ) )
         {
-            *pcFileName = pkcs11palFILE_NAME_KEY;
+            *pcFileName = pkcs11palFILE_NAME_PUBLIC_KEY;
             *pHandle = ( CK_OBJECT_HANDLE ) eAwsDevicePublicKey;
         }
         else if( 0 == strncmp( pkcs11configLABEL_CODE_VERIFICATION_KEY,
@@ -136,6 +139,13 @@ static void prvLabelToFilenameHandle( const char * pcLabel,
         {
             *pcFileName = pkcs11palFILE_CODE_SIGN_PUBLIC_KEY;
             *pHandle = ( CK_OBJECT_HANDLE ) eAwsCodeSigningKey;
+        }
+        else if( 0 == strncmp( pkcs11configLABEL_HMAC_KEY,
+                               pcLabel,
+                               sizeof( pkcs11configLABEL_HMAC_KEY ) ) )
+        {
+            *pcFileName = pkcs11palFILE_HMAC_SECRET_KEY;
+            *pHandle = ( CK_OBJECT_HANDLE ) eAwsHMACSecretKey;
         }
         else
         {
@@ -182,7 +192,7 @@ static CK_RV prvHandleToFilename( CK_OBJECT_HANDLE xHandle,
                 break;
 
             case eAwsDevicePublicKey:
-                *pcFileName = pkcs11palFILE_NAME_KEY;
+                *pcFileName = pkcs11palFILE_NAME_PUBLIC_KEY;
                 /* coverity[misra_c_2012_rule_10_5_violation] */
                 *pIsPrivate = ( CK_BBOOL ) CK_FALSE;
                 break;
@@ -191,6 +201,12 @@ static CK_RV prvHandleToFilename( CK_OBJECT_HANDLE xHandle,
                 *pcFileName = pkcs11palFILE_CODE_SIGN_PUBLIC_KEY;
                 /* coverity[misra_c_2012_rule_10_5_violation] */
                 *pIsPrivate = ( CK_BBOOL ) CK_FALSE;
+                break;
+
+            case  eAwsHMACSecretKey:
+                *pcFileName = pkcs11palFILE_HMAC_SECRET_KEY;
+                /* coverity[misra_c_2012_rule_10_5_violation] */
+                *pIsPrivate = ( CK_BBOOL ) CK_TRUE;
                 break;
 
             default:

--- a/test/cbmc/proofs/C_CreateObject/C_CreateObject_harness.c
+++ b/test/cbmc/proofs/C_CreateObject/C_CreateObject_harness.c
@@ -55,7 +55,7 @@ typedef struct P11Session
     CK_OBJECT_HANDLE xSignKeyHandle;
     mbedtls_pk_context xSignKey;
     mbedtls_sha256_context xSHA256Context;
-    CK_OBJECT_HANDLE xHMACKeyHandle;     
+    CK_OBJECT_HANDLE xHMACKeyHandle;
     mbedtls_md_context_t xHMACSecretContext;
 } P11Session_t;
 

--- a/test/cbmc/proofs/C_CreateObject/C_CreateObject_harness.c
+++ b/test/cbmc/proofs/C_CreateObject/C_CreateObject_harness.c
@@ -55,6 +55,8 @@ typedef struct P11Session
     CK_OBJECT_HANDLE xSignKeyHandle;
     mbedtls_pk_context xSignKey;
     mbedtls_sha256_context xSHA256Context;
+    CK_OBJECT_HANDLE xHMACKeyHandle;     
+    mbedtls_md_context_t xHMACSecretContext;
 } P11Session_t;
 
 CK_RV __CPROVER_file_local_core_pkcs11_mbedtls_c_prvCheckValidSessionAndModule( const P11Session_t * pxSession )

--- a/test/cbmc/proofs/C_CreateObject/Makefile
+++ b/test/cbmc/proofs/C_CreateObject/Makefile
@@ -50,6 +50,7 @@ UNWINDSET += __CPROVER_file_local_core_pkcs11_mbedtls_c_prvGetObjectClass.0:$(TE
 UNWINDSET += __CPROVER_file_local_core_pkcs11_mbedtls_c_prvCreateECKey.0:$(TEMPLATE_SIZE)
 UNWINDSET += __CPROVER_file_local_core_pkcs11_mbedtls_c_prvGetLabel.0:$(TEMPLATE_SIZE)
 UNWINDSET += __CPROVER_file_local_core_pkcs11_mbedtls_c_prvCreateRsaKey.0:$(TEMPLATE_SIZE)
+UNWINDSET += __CPROVER_file_local_core_pkcs11_mbedtls_c_prvCreateSHA256HMAC.0:$(TEMPLATE_SIZE)
 UNWINDSET += __CPROVER_file_local_core_pkcs11_mbedtls_c_prvAddObjectToList.0:$(MAX_OBJECT_NUM)
 UNWINDSET += harness.0:$(TEMPLATE_SIZE)
 UNWINDSET += memcmp.0:$(MAX_LABEL_SIZE)

--- a/test/cbmc/proofs/C_DestroyObject/C_DestroyObject_harness.c
+++ b/test/cbmc/proofs/C_DestroyObject/C_DestroyObject_harness.c
@@ -55,7 +55,7 @@ typedef struct P11Session
     CK_OBJECT_HANDLE xSignKeyHandle;
     mbedtls_pk_context xSignKey;
     mbedtls_sha256_context xSHA256Context;
-    CK_OBJECT_HANDLE xHMACKeyHandle;     
+    CK_OBJECT_HANDLE xHMACKeyHandle;
     mbedtls_md_context_t xHMACSecretContext;
 } P11Session_t;
 

--- a/test/cbmc/proofs/C_DestroyObject/C_DestroyObject_harness.c
+++ b/test/cbmc/proofs/C_DestroyObject/C_DestroyObject_harness.c
@@ -55,6 +55,8 @@ typedef struct P11Session
     CK_OBJECT_HANDLE xSignKeyHandle;
     mbedtls_pk_context xSignKey;
     mbedtls_sha256_context xSHA256Context;
+    CK_OBJECT_HANDLE xHMACKeyHandle;     
+    mbedtls_md_context_t xHMACSecretContext;
 } P11Session_t;
 
 CK_RV __CPROVER_file_local_core_pkcs11_mbedtls_c_prvCheckValidSessionAndModule( const P11Session_t * pxSession )

--- a/test/cbmc/proofs/C_DigestFinal/C_DigestFinal_harness.c
+++ b/test/cbmc/proofs/C_DigestFinal/C_DigestFinal_harness.c
@@ -54,7 +54,7 @@ typedef struct P11Session
     CK_OBJECT_HANDLE xSignKeyHandle;
     mbedtls_pk_context xSignKey;
     mbedtls_sha256_context xSHA256Context;
-    CK_OBJECT_HANDLE xHMACKeyHandle;     
+    CK_OBJECT_HANDLE xHMACKeyHandle;
     mbedtls_md_context_t xHMACSecretContext;
 } P11Session_t;
 

--- a/test/cbmc/proofs/C_DigestFinal/C_DigestFinal_harness.c
+++ b/test/cbmc/proofs/C_DigestFinal/C_DigestFinal_harness.c
@@ -54,6 +54,8 @@ typedef struct P11Session
     CK_OBJECT_HANDLE xSignKeyHandle;
     mbedtls_pk_context xSignKey;
     mbedtls_sha256_context xSHA256Context;
+    CK_OBJECT_HANDLE xHMACKeyHandle;     
+    mbedtls_md_context_t xHMACSecretContext;
 } P11Session_t;
 
 CK_RV __CPROVER_file_local_core_pkcs11_mbedtls_c_prvCheckValidSessionAndModule( P11Session_t * pxSession )

--- a/test/cbmc/proofs/C_DigestInit/C_DigestInit_harness.c
+++ b/test/cbmc/proofs/C_DigestInit/C_DigestInit_harness.c
@@ -54,7 +54,7 @@ typedef struct P11Session
     CK_OBJECT_HANDLE xSignKeyHandle;
     mbedtls_pk_context xSignKey;
     mbedtls_sha256_context xSHA256Context;
-    CK_OBJECT_HANDLE xHMACKeyHandle;     
+    CK_OBJECT_HANDLE xHMACKeyHandle;
     mbedtls_md_context_t xHMACSecretContext;
 } P11Session_t;
 

--- a/test/cbmc/proofs/C_DigestInit/C_DigestInit_harness.c
+++ b/test/cbmc/proofs/C_DigestInit/C_DigestInit_harness.c
@@ -54,6 +54,8 @@ typedef struct P11Session
     CK_OBJECT_HANDLE xSignKeyHandle;
     mbedtls_pk_context xSignKey;
     mbedtls_sha256_context xSHA256Context;
+    CK_OBJECT_HANDLE xHMACKeyHandle;     
+    mbedtls_md_context_t xHMACSecretContext;
 } P11Session_t;
 
 CK_RV __CPROVER_file_local_core_pkcs11_mbedtls_c_prvCheckValidSessionAndModule( const P11Session_t * pxSession )

--- a/test/cbmc/proofs/C_DigestUpdate/C_DigestUpdate_harness.c
+++ b/test/cbmc/proofs/C_DigestUpdate/C_DigestUpdate_harness.c
@@ -54,7 +54,7 @@ typedef struct P11Session
     CK_OBJECT_HANDLE xSignKeyHandle;
     mbedtls_pk_context xSignKey;
     mbedtls_sha256_context xSHA256Context;
-    CK_OBJECT_HANDLE xHMACKeyHandle;     
+    CK_OBJECT_HANDLE xHMACKeyHandle;
     mbedtls_md_context_t xHMACSecretContext;
 } P11Session_t;
 

--- a/test/cbmc/proofs/C_DigestUpdate/C_DigestUpdate_harness.c
+++ b/test/cbmc/proofs/C_DigestUpdate/C_DigestUpdate_harness.c
@@ -54,6 +54,8 @@ typedef struct P11Session
     CK_OBJECT_HANDLE xSignKeyHandle;
     mbedtls_pk_context xSignKey;
     mbedtls_sha256_context xSHA256Context;
+    CK_OBJECT_HANDLE xHMACKeyHandle;     
+    mbedtls_md_context_t xHMACSecretContext;
 } P11Session_t;
 
 CK_RV __CPROVER_file_local_core_pkcs11_mbedtls_c_prvCheckValidSessionAndModule( P11Session_t * pxSession )

--- a/test/cbmc/proofs/C_FindObjects/C_FindObjects_harness.c
+++ b/test/cbmc/proofs/C_FindObjects/C_FindObjects_harness.c
@@ -59,6 +59,8 @@ typedef struct P11Session
     CK_OBJECT_HANDLE xSignKeyHandle;
     mbedtls_pk_context xSignKey;
     mbedtls_sha256_context xSHA256Context;
+    CK_OBJECT_HANDLE xHMACKeyHandle;     
+    mbedtls_md_context_t xHMACSecretContext;
 } P11Session_t;
 
 CK_RV __CPROVER_file_local_core_pkcs11_mbedtls_c_prvCheckValidSessionAndModule( P11Session_t * pxSession )

--- a/test/cbmc/proofs/C_FindObjects/C_FindObjects_harness.c
+++ b/test/cbmc/proofs/C_FindObjects/C_FindObjects_harness.c
@@ -59,7 +59,7 @@ typedef struct P11Session
     CK_OBJECT_HANDLE xSignKeyHandle;
     mbedtls_pk_context xSignKey;
     mbedtls_sha256_context xSHA256Context;
-    CK_OBJECT_HANDLE xHMACKeyHandle;     
+    CK_OBJECT_HANDLE xHMACKeyHandle;
     mbedtls_md_context_t xHMACSecretContext;
 } P11Session_t;
 

--- a/test/cbmc/proofs/C_FindObjectsFinal/C_FindObjectsFinal_harness.c
+++ b/test/cbmc/proofs/C_FindObjectsFinal/C_FindObjectsFinal_harness.c
@@ -59,6 +59,8 @@ typedef struct P11Session
     CK_OBJECT_HANDLE xSignKeyHandle;
     mbedtls_pk_context xSignKey;
     mbedtls_sha256_context xSHA256Context;
+    CK_OBJECT_HANDLE xHMACKeyHandle;     
+    mbedtls_md_context_t xHMACSecretContext;
 } P11Session_t;
 
 CK_RV __CPROVER_file_local_core_pkcs11_mbedtls_c_prvCheckValidSessionAndModule( P11Session_t * pxSession )

--- a/test/cbmc/proofs/C_FindObjectsFinal/C_FindObjectsFinal_harness.c
+++ b/test/cbmc/proofs/C_FindObjectsFinal/C_FindObjectsFinal_harness.c
@@ -59,7 +59,7 @@ typedef struct P11Session
     CK_OBJECT_HANDLE xSignKeyHandle;
     mbedtls_pk_context xSignKey;
     mbedtls_sha256_context xSHA256Context;
-    CK_OBJECT_HANDLE xHMACKeyHandle;     
+    CK_OBJECT_HANDLE xHMACKeyHandle;
     mbedtls_md_context_t xHMACSecretContext;
 } P11Session_t;
 

--- a/test/cbmc/proofs/C_FindObjectsInit/C_FindObjectsInit_harness.c
+++ b/test/cbmc/proofs/C_FindObjectsInit/C_FindObjectsInit_harness.c
@@ -58,6 +58,8 @@ typedef struct P11Session
     CK_OBJECT_HANDLE xSignKeyHandle;
     mbedtls_pk_context xSignKey;
     mbedtls_sha256_context xSHA256Context;
+    CK_OBJECT_HANDLE xHMACKeyHandle;     
+    mbedtls_md_context_t xHMACSecretContext;
 } P11Session_t;
 
 CK_RV __CPROVER_file_local_core_pkcs11_mbedtls_c_prvCheckValidSessionAndModule( const P11Session_t * pxSession )

--- a/test/cbmc/proofs/C_FindObjectsInit/C_FindObjectsInit_harness.c
+++ b/test/cbmc/proofs/C_FindObjectsInit/C_FindObjectsInit_harness.c
@@ -58,7 +58,7 @@ typedef struct P11Session
     CK_OBJECT_HANDLE xSignKeyHandle;
     mbedtls_pk_context xSignKey;
     mbedtls_sha256_context xSHA256Context;
-    CK_OBJECT_HANDLE xHMACKeyHandle;     
+    CK_OBJECT_HANDLE xHMACKeyHandle;
     mbedtls_md_context_t xHMACSecretContext;
 } P11Session_t;
 

--- a/test/cbmc/proofs/C_GenerateKeyPair/C_GenerateKeyPair_harness.c
+++ b/test/cbmc/proofs/C_GenerateKeyPair/C_GenerateKeyPair_harness.c
@@ -55,7 +55,7 @@ typedef struct P11Session
     CK_OBJECT_HANDLE xSignKeyHandle;
     mbedtls_pk_context xSignKey;
     mbedtls_sha256_context xSHA256Context;
-    CK_OBJECT_HANDLE xHMACKeyHandle;     
+    CK_OBJECT_HANDLE xHMACKeyHandle;
     mbedtls_md_context_t xHMACSecretContext;
 } P11Session_t;
 

--- a/test/cbmc/proofs/C_GenerateKeyPair/C_GenerateKeyPair_harness.c
+++ b/test/cbmc/proofs/C_GenerateKeyPair/C_GenerateKeyPair_harness.c
@@ -55,6 +55,8 @@ typedef struct P11Session
     CK_OBJECT_HANDLE xSignKeyHandle;
     mbedtls_pk_context xSignKey;
     mbedtls_sha256_context xSHA256Context;
+    CK_OBJECT_HANDLE xHMACKeyHandle;     
+    mbedtls_md_context_t xHMACSecretContext;
 } P11Session_t;
 
 CK_RV __CPROVER_file_local_core_pkcs11_mbedtls_c_prvCheckValidSessionAndModule( const P11Session_t * pxSession )

--- a/test/cbmc/proofs/C_GenerateRandom/C_GenerateRandom_harness.c
+++ b/test/cbmc/proofs/C_GenerateRandom/C_GenerateRandom_harness.c
@@ -55,7 +55,7 @@ typedef struct P11Session
     CK_OBJECT_HANDLE xSignKeyHandle;
     mbedtls_pk_context xSignKey;
     mbedtls_sha256_context xSHA256Context;
-    CK_OBJECT_HANDLE xHMACKeyHandle;     
+    CK_OBJECT_HANDLE xHMACKeyHandle;
     mbedtls_md_context_t xHMACSecretContext;
 } P11Session_t;
 

--- a/test/cbmc/proofs/C_GenerateRandom/C_GenerateRandom_harness.c
+++ b/test/cbmc/proofs/C_GenerateRandom/C_GenerateRandom_harness.c
@@ -55,6 +55,8 @@ typedef struct P11Session
     CK_OBJECT_HANDLE xSignKeyHandle;
     mbedtls_pk_context xSignKey;
     mbedtls_sha256_context xSHA256Context;
+    CK_OBJECT_HANDLE xHMACKeyHandle;     
+    mbedtls_md_context_t xHMACSecretContext;
 } P11Session_t;
 
 CK_RV __CPROVER_file_local_core_pkcs11_mbedtls_c_prvCheckValidSessionAndModule( const P11Session_t * pxSession )

--- a/test/cbmc/proofs/C_GetAttributeValue/C_GetAttributeValue_harness.c
+++ b/test/cbmc/proofs/C_GetAttributeValue/C_GetAttributeValue_harness.c
@@ -55,7 +55,7 @@ typedef struct P11Session
     CK_OBJECT_HANDLE xSignKeyHandle;
     mbedtls_pk_context xSignKey;
     mbedtls_sha256_context xSHA256Context;
-    CK_OBJECT_HANDLE xHMACKeyHandle;     
+    CK_OBJECT_HANDLE xHMACKeyHandle;
     mbedtls_md_context_t xHMACSecretContext;
 } P11Session_t;
 

--- a/test/cbmc/proofs/C_GetAttributeValue/C_GetAttributeValue_harness.c
+++ b/test/cbmc/proofs/C_GetAttributeValue/C_GetAttributeValue_harness.c
@@ -55,6 +55,8 @@ typedef struct P11Session
     CK_OBJECT_HANDLE xSignKeyHandle;
     mbedtls_pk_context xSignKey;
     mbedtls_sha256_context xSHA256Context;
+    CK_OBJECT_HANDLE xHMACKeyHandle;     
+    mbedtls_md_context_t xHMACSecretContext;
 } P11Session_t;
 
 CK_RV __CPROVER_file_local_core_pkcs11_mbedtls_c_prvCheckValidSessionAndModule( const P11Session_t * pxSession )

--- a/test/cbmc/proofs/C_Sign/C_Sign_harness.c
+++ b/test/cbmc/proofs/C_Sign/C_Sign_harness.c
@@ -56,7 +56,7 @@ typedef struct P11Session
     CK_OBJECT_HANDLE xSignKeyHandle;
     mbedtls_pk_context xSignKey;
     mbedtls_sha256_context xSHA256Context;
-    CK_OBJECT_HANDLE xHMACKeyHandle;     
+    CK_OBJECT_HANDLE xHMACKeyHandle;
     mbedtls_md_context_t xHMACSecretContext;
 } P11Session_t;
 

--- a/test/cbmc/proofs/C_Sign/C_Sign_harness.c
+++ b/test/cbmc/proofs/C_Sign/C_Sign_harness.c
@@ -56,6 +56,8 @@ typedef struct P11Session
     CK_OBJECT_HANDLE xSignKeyHandle;
     mbedtls_pk_context xSignKey;
     mbedtls_sha256_context xSHA256Context;
+    CK_OBJECT_HANDLE xHMACKeyHandle;     
+    mbedtls_md_context_t xHMACSecretContext;
 } P11Session_t;
 
 CK_RV __CPROVER_file_local_core_pkcs11_mbedtls_c_prvCheckValidSessionAndModule( P11Session_t * pxSession )

--- a/test/cbmc/proofs/C_SignInit/C_SignInit_harness.c
+++ b/test/cbmc/proofs/C_SignInit/C_SignInit_harness.c
@@ -55,7 +55,7 @@ typedef struct P11Session
     CK_OBJECT_HANDLE xSignKeyHandle;
     mbedtls_pk_context xSignKey;
     mbedtls_sha256_context xSHA256Context;
-    CK_OBJECT_HANDLE xHMACKeyHandle;     
+    CK_OBJECT_HANDLE xHMACKeyHandle;
     mbedtls_md_context_t xHMACSecretContext;
 } P11Session_t;
 

--- a/test/cbmc/proofs/C_SignInit/C_SignInit_harness.c
+++ b/test/cbmc/proofs/C_SignInit/C_SignInit_harness.c
@@ -55,6 +55,8 @@ typedef struct P11Session
     CK_OBJECT_HANDLE xSignKeyHandle;
     mbedtls_pk_context xSignKey;
     mbedtls_sha256_context xSHA256Context;
+    CK_OBJECT_HANDLE xHMACKeyHandle;     
+    mbedtls_md_context_t xHMACSecretContext;
 } P11Session_t;
 
 CK_RV __CPROVER_file_local_core_pkcs11_mbedtls_c_prvCheckValidSessionAndModule( const P11Session_t * pxSession )

--- a/test/cbmc/proofs/C_Verify/C_Verify_harness.c
+++ b/test/cbmc/proofs/C_Verify/C_Verify_harness.c
@@ -57,6 +57,8 @@ typedef struct P11Session
     CK_OBJECT_HANDLE xSignKeyHandle;
     mbedtls_pk_context xSignKey;
     mbedtls_sha256_context xSHA256Context;
+    CK_OBJECT_HANDLE xHMACKeyHandle;     
+    mbedtls_md_context_t xHMACSecretContext;
 } P11Session_t;
 
 

--- a/test/cbmc/proofs/C_Verify/C_Verify_harness.c
+++ b/test/cbmc/proofs/C_Verify/C_Verify_harness.c
@@ -57,7 +57,7 @@ typedef struct P11Session
     CK_OBJECT_HANDLE xSignKeyHandle;
     mbedtls_pk_context xSignKey;
     mbedtls_sha256_context xSHA256Context;
-    CK_OBJECT_HANDLE xHMACKeyHandle;     
+    CK_OBJECT_HANDLE xHMACKeyHandle;
     mbedtls_md_context_t xHMACSecretContext;
 } P11Session_t;
 

--- a/test/cbmc/proofs/C_VerifyInit/C_VerifyInit_harness.c
+++ b/test/cbmc/proofs/C_VerifyInit/C_VerifyInit_harness.c
@@ -55,7 +55,7 @@ typedef struct P11Session
     CK_OBJECT_HANDLE xSignKeyHandle;
     mbedtls_pk_context xSignKey;
     mbedtls_sha256_context xSHA256Context;
-    CK_OBJECT_HANDLE xHMACKeyHandle;     
+    CK_OBJECT_HANDLE xHMACKeyHandle;
     mbedtls_md_context_t xHMACSecretContext;
 } P11Session_t;
 

--- a/test/cbmc/proofs/C_VerifyInit/C_VerifyInit_harness.c
+++ b/test/cbmc/proofs/C_VerifyInit/C_VerifyInit_harness.c
@@ -55,6 +55,8 @@ typedef struct P11Session
     CK_OBJECT_HANDLE xSignKeyHandle;
     mbedtls_pk_context xSignKey;
     mbedtls_sha256_context xSHA256Context;
+    CK_OBJECT_HANDLE xHMACKeyHandle;     
+    mbedtls_md_context_t xHMACSecretContext;
 } P11Session_t;
 
 CK_RV __CPROVER_file_local_core_pkcs11_mbedtls_c_prvCheckValidSessionAndModule( const P11Session_t * pxSession )

--- a/test/system-test/test-config/core_pkcs11_config.h
+++ b/test/system-test/test-config/core_pkcs11_config.h
@@ -154,6 +154,11 @@
 #define pkcs11configLABEL_DEVICE_CERTIFICATE_FOR_TLS       "Device Cert"
 
 /**
+ * @brief The PKCS #11 label for the object to be used for HMAC operations.
+ */
+#define pkcs11configLABEL_HMAC_KEY                         "HMAC Key"
+
+/**
  * @brief The PKCS #11 label for the object to be used for code verification.
  *
  * Used by over-the-air update code to verify an incoming signed image.

--- a/test/system-test/test-config/core_test_pkcs11_config.h
+++ b/test/system-test/test-config/core_test_pkcs11_config.h
@@ -117,7 +117,7 @@
  * For devices with secure elements or hardware limitations, this may be defined
  * to a different label to preserve AWS IoT credentials for other test suites.
  */
-#define pkcs11testLABEL_HMAC_KEY                           pkcs11configLABEL_HMAC_KEY
+#define pkcs11testLABEL_HMAC_KEY                      pkcs11configLABEL_HMAC_KEY
 
 /**
  * @brief The PKCS #11 label for the AWS Trusted Root Certificate.

--- a/test/system-test/test-config/core_test_pkcs11_config.h
+++ b/test/system-test/test-config/core_test_pkcs11_config.h
@@ -111,6 +111,15 @@
 #define pkcs11testLABEL_JITP_CERTIFICATE              pkcs11configLABEL_JITP_CERTIFICATE
 
 /**
+ * @brief The PKCS #11 label for the object to be used for HMAC operations.
+ *
+ * For devices with on-chip storage, this should match the non-test label.
+ * For devices with secure elements or hardware limitations, this may be defined
+ * to a different label to preserve AWS IoT credentials for other test suites.
+ */
+#define pkcs11testLABEL_HMAC_KEY                           pkcs11configLABEL_HMAC_KEY
+
+/**
  * @brief The PKCS #11 label for the AWS Trusted Root Certificate.
  *
  * @see aws_default_root_certificates.h

--- a/test/unit-test/config/core_pkcs11_config.h
+++ b/test/unit-test/config/core_pkcs11_config.h
@@ -135,6 +135,11 @@
 #define pkcs11configLABEL_DEVICE_CERTIFICATE_FOR_TLS       "Device Cert"
 
 /**
+ * @brief The PKCS #11 label for the object to be used for HMAC operations.
+ */
+#define pkcs11configLABEL_HMAC_KEY                         "HMAC Key"
+
+/**
  * @brief The PKCS #11 label for the object to be used for code verification.
  *
  * Used by over-the-air update code to verify an incoming signed image.

--- a/test/unit-test/core_pkcs11_mbedtls_utest.c
+++ b/test/unit-test/core_pkcs11_mbedtls_utest.c
@@ -2109,6 +2109,349 @@ void test_pkcs11_C_CreateObjectCertificateUnkownAtt( void )
 
     prvCommonDeinitStubs();
 }
+
+/*!
+ * @brief C_CreateObject Creating a SHA256-HMAC secret key happy path.
+ *
+ */
+void test_pkcs11_C_CreateObjectSHA256HMACKey( void )
+{
+    CK_RV xResult = CKR_OK;
+    CK_SESSION_HANDLE xSession = CK_INVALID_HANDLE;
+    CK_KEY_TYPE xKeyType = CKK_SHA256_HMAC;
+    CK_OBJECT_CLASS xKeyClass = CKO_SECRET_KEY;
+    CK_BBOOL xTrue = CK_TRUE;
+    CK_OBJECT_HANDLE xObject = CK_INVALID_HANDLE;
+    CK_BYTE pcLabel[] = pkcs11configLABEL_HMAC_KEY;
+
+    CK_BYTE pxKeyValue[] = "abcdabcdabcdabcdabcdabcdabcdabcd";
+
+    CK_ATTRIBUTE xSHA256HMACTemplate[] =
+    {
+        { CKA_CLASS,    &xKeyClass, sizeof( CK_OBJECT_CLASS ) },
+        { CKA_KEY_TYPE, &xKeyType,  sizeof( CK_KEY_TYPE )     },
+        { CKA_LABEL,    pcLabel,    sizeof( pcLabel ) - 1     },
+        { CKA_TOKEN,    &xTrue,     sizeof( CK_BBOOL )        },
+        { CKA_SIGN,     &xTrue,     sizeof( CK_BBOOL )        },
+        { CKA_VERIFY,   &xTrue,     sizeof( CK_BBOOL )        },
+        { CKA_VALUE,    pxKeyValue, sizeof( pxKeyValue ) - 1  }
+    };
+
+    prvCommonInitStubs();
+
+    if( TEST_PROTECT() )
+    {
+        PKCS11_PAL_SaveObject_IgnoreAndReturn( 1 );
+        mock_osal_mutex_lock_IgnoreAndReturn( 0 );
+        mock_osal_mutex_unlock_IgnoreAndReturn( 0 );
+        xResult = C_CreateObject( xSession,
+                                  ( CK_ATTRIBUTE_PTR ) &xSHA256HMACTemplate,
+                                  sizeof( xSHA256HMACTemplate ) / sizeof( CK_ATTRIBUTE ),
+                                  &xObject );
+
+        TEST_ASSERT_EQUAL( CKR_OK, xResult );
+    }
+
+    prvCommonDeinitStubs();
+}
+
+/*!
+ * @brief C_CreateObject Creating a SHA256-HMAC invalid token values.
+ *
+ */
+void test_pkcs11_C_CreateObjectSHA256HMACKeyBadAtts( void )
+{
+    CK_RV xResult = CKR_OK;
+    CK_SESSION_HANDLE xSession = CK_INVALID_HANDLE;
+    CK_KEY_TYPE xKeyType = CKK_SHA256_HMAC;
+    CK_OBJECT_CLASS xKeyClass = CKO_SECRET_KEY;
+    CK_BBOOL xFalse = CK_FALSE;
+    CK_OBJECT_HANDLE xObject = CK_INVALID_HANDLE;
+    CK_BYTE pcLabel[] = pkcs11configLABEL_HMAC_KEY;
+
+    CK_BYTE pxKeyValue[] = "abcdabcdabcdabcdabcdabcdabcdabcd";
+
+    CK_ATTRIBUTE xSHA256HMACTemplate[] =
+    {
+        { CKA_CLASS,    &xKeyClass, sizeof( CK_OBJECT_CLASS ) },
+        { CKA_KEY_TYPE, &xKeyType,  sizeof( CK_KEY_TYPE )     },
+        { CKA_LABEL,    pcLabel,    sizeof( pcLabel ) - 1     },
+        { CKA_TOKEN,    &xFalse,    sizeof( CK_BBOOL )        },
+        { CKA_SIGN,     &xFalse,    sizeof( CK_BBOOL )        },
+        { CKA_VERIFY,   &xFalse,    sizeof( CK_BBOOL )        },
+        { CKA_VALUE,    pxKeyValue, sizeof( pxKeyValue ) - 1  }
+    };
+
+    prvCommonInitStubs();
+
+    if( TEST_PROTECT() )
+    {
+        xResult = C_CreateObject( xSession,
+                                  ( CK_ATTRIBUTE_PTR ) &xSHA256HMACTemplate,
+                                  sizeof( xSHA256HMACTemplate ) / sizeof( CK_ATTRIBUTE ),
+                                  &xObject );
+
+        TEST_ASSERT_EQUAL( CKR_ATTRIBUTE_VALUE_INVALID, xResult );
+    }
+
+    prvCommonDeinitStubs();
+}
+
+/*!
+ * @brief C_CreateObject Creating a SHA256-HMAC unknown attribute.
+ *
+ */
+void test_pkcs11_C_CreateObjectSHA256HMACKeyUnknownAtt( void )
+{
+    CK_RV xResult = CKR_OK;
+    CK_SESSION_HANDLE xSession = CK_INVALID_HANDLE;
+    CK_KEY_TYPE xKeyType = CKK_SHA256_HMAC;
+    CK_OBJECT_CLASS xKeyClass = CKO_SECRET_KEY;
+    CK_BBOOL xTrue = CK_TRUE;
+    CK_OBJECT_HANDLE xObject = CK_INVALID_HANDLE;
+    CK_BYTE pcLabel[] = pkcs11configLABEL_HMAC_KEY;
+
+    CK_BYTE pxKeyValue[] = "abcdabcdabcdabcdabcdabcdabcdabcd";
+
+    CK_ATTRIBUTE xSHA256HMACTemplate[] =
+    {
+        { CKA_CLASS,    &xKeyClass, sizeof( CK_OBJECT_CLASS ) },
+        { CKA_KEY_TYPE, &xKeyType,  sizeof( CK_KEY_TYPE )     },
+        { CKA_LABEL,    pcLabel,    sizeof( pcLabel ) - 1     },
+        { CKA_SUBJECT,  &xTrue,     sizeof( CK_BBOOL )        },
+        { CKA_SIGN,     &xTrue,     sizeof( CK_BBOOL )        },
+        { CKA_VERIFY,   &xTrue,     sizeof( CK_BBOOL )        },
+        { CKA_VALUE,    pxKeyValue, sizeof( pxKeyValue ) - 1  }
+    };
+
+    prvCommonInitStubs();
+
+    if( TEST_PROTECT() )
+    {
+        xResult = C_CreateObject( xSession,
+                                  ( CK_ATTRIBUTE_PTR ) &xSHA256HMACTemplate,
+                                  sizeof( xSHA256HMACTemplate ) / sizeof( CK_ATTRIBUTE ),
+                                  &xObject );
+
+        TEST_ASSERT_EQUAL( CKR_ATTRIBUTE_TYPE_INVALID, xResult );
+    }
+
+    prvCommonDeinitStubs();
+}
+
+/*!
+ * @brief C_CreateObject Creating a SHA256-HMAC missing label.
+ *
+ */
+void test_pkcs11_C_CreateObjectSHA256HMACKeyMissingLabel( void )
+{
+    CK_RV xResult = CKR_OK;
+    CK_SESSION_HANDLE xSession = CK_INVALID_HANDLE;
+    CK_KEY_TYPE xKeyType = CKK_SHA256_HMAC;
+    CK_OBJECT_CLASS xKeyClass = CKO_SECRET_KEY;
+    CK_BBOOL xTrue = CK_TRUE;
+    CK_OBJECT_HANDLE xObject = CK_INVALID_HANDLE;
+    CK_BYTE pcLabel[] = pkcs11configLABEL_HMAC_KEY;
+
+    CK_BYTE pxKeyValue[] = "abcdabcdabcdabcdabcdabcdabcdabcd";
+
+    CK_ATTRIBUTE xSHA256HMACTemplate[] =
+    {
+        { CKA_CLASS,    &xKeyClass, sizeof( CK_OBJECT_CLASS ) },
+        { CKA_KEY_TYPE, &xKeyType,  sizeof( CK_KEY_TYPE )     },
+        { CKA_TOKEN,    &xTrue,     sizeof( CK_BBOOL )        },
+        { CKA_SIGN,     &xTrue,     sizeof( CK_BBOOL )        },
+        { CKA_VERIFY,   &xTrue,     sizeof( CK_BBOOL )        },
+        { CKA_VALUE,    pxKeyValue, sizeof( pxKeyValue ) - 1  }
+    };
+
+    prvCommonInitStubs();
+
+    if( TEST_PROTECT() )
+    {
+        xResult = C_CreateObject( xSession,
+                                  ( CK_ATTRIBUTE_PTR ) &xSHA256HMACTemplate,
+                                  sizeof( xSHA256HMACTemplate ) / sizeof( CK_ATTRIBUTE ),
+                                  &xObject );
+
+        TEST_ASSERT_EQUAL( CKR_ARGUMENTS_BAD, xResult );
+    }
+
+    prvCommonDeinitStubs();
+}
+
+/*!
+ * @brief C_CreateObject Creating a SHA256-HMAC NULL secret key.
+ *
+ */
+void test_pkcs11_C_CreateObjectSHA256HMACKeyNullSecretKey( void )
+{
+    CK_RV xResult = CKR_OK;
+    CK_SESSION_HANDLE xSession = CK_INVALID_HANDLE;
+    CK_KEY_TYPE xKeyType = CKK_SHA256_HMAC;
+    CK_OBJECT_CLASS xKeyClass = CKO_SECRET_KEY;
+    CK_BBOOL xTrue = CK_TRUE;
+    CK_OBJECT_HANDLE xObject = CK_INVALID_HANDLE;
+    CK_BYTE pcLabel[] = pkcs11configLABEL_HMAC_KEY;
+
+    CK_ATTRIBUTE xSHA256HMACTemplate[] =
+    {
+        { CKA_CLASS,    &xKeyClass, sizeof( CK_OBJECT_CLASS ) },
+        { CKA_KEY_TYPE, &xKeyType,  sizeof( CK_KEY_TYPE )     },
+        { CKA_LABEL,    pcLabel,    sizeof( pcLabel ) - 1     },
+        { CKA_TOKEN,    &xTrue,     sizeof( CK_BBOOL )        },
+        { CKA_SIGN,     &xTrue,     sizeof( CK_BBOOL )        },
+        { CKA_VERIFY,   &xTrue,     sizeof( CK_BBOOL )        },
+        { CKA_VALUE,    NULL,       0                         }
+    };
+
+    prvCommonInitStubs();
+
+    if( TEST_PROTECT() )
+    {
+        PKCS11_PAL_SaveObject_IgnoreAndReturn( 0 );
+        xResult = C_CreateObject( xSession,
+                                  ( CK_ATTRIBUTE_PTR ) &xSHA256HMACTemplate,
+                                  sizeof( xSHA256HMACTemplate ) / sizeof( CK_ATTRIBUTE ),
+                                  &xObject );
+
+        TEST_ASSERT_EQUAL( CKR_ATTRIBUTE_VALUE_INVALID, xResult );
+    }
+
+    prvCommonDeinitStubs();
+}
+
+/*!
+ * @brief C_CreateObject Creating a SHA256-HMAC short secret key.
+ *
+ */
+void test_pkcs11_C_CreateObjectSHA256HMACKeyShortSecretKey( void )
+{
+    CK_RV xResult = CKR_OK;
+    CK_SESSION_HANDLE xSession = CK_INVALID_HANDLE;
+    CK_KEY_TYPE xKeyType = CKK_SHA256_HMAC;
+    CK_OBJECT_CLASS xKeyClass = CKO_SECRET_KEY;
+    CK_BBOOL xTrue = CK_TRUE;
+    CK_OBJECT_HANDLE xObject = CK_INVALID_HANDLE;
+    CK_BYTE pcLabel[] = pkcs11configLABEL_HMAC_KEY;
+
+    CK_BYTE pxKeyValue[] = "abcdabcdabcdabcd";
+
+    CK_ATTRIBUTE xSHA256HMACTemplate[] =
+    {
+        { CKA_CLASS,    &xKeyClass, sizeof( CK_OBJECT_CLASS ) },
+        { CKA_KEY_TYPE, &xKeyType,  sizeof( CK_KEY_TYPE )     },
+        { CKA_LABEL,    pcLabel,    sizeof( pcLabel ) - 1     },
+        { CKA_TOKEN,    &xTrue,     sizeof( CK_BBOOL )        },
+        { CKA_SIGN,     &xTrue,     sizeof( CK_BBOOL )        },
+        { CKA_VERIFY,   &xTrue,     sizeof( CK_BBOOL )        },
+        { CKA_VALUE,    pxKeyValue, sizeof( pxKeyValue ) - 1  }
+    };
+
+    prvCommonInitStubs();
+
+    if( TEST_PROTECT() )
+    {
+        PKCS11_PAL_SaveObject_IgnoreAndReturn( 0 );
+        xResult = C_CreateObject( xSession,
+                                  ( CK_ATTRIBUTE_PTR ) &xSHA256HMACTemplate,
+                                  sizeof( xSHA256HMACTemplate ) / sizeof( CK_ATTRIBUTE ),
+                                  &xObject );
+
+        TEST_ASSERT_EQUAL( CKR_ATTRIBUTE_VALUE_INVALID, xResult );
+    }
+
+    prvCommonDeinitStubs();
+}
+
+/*!
+ * @brief C_CreateObject Creating a SHA256-HMAC secret key fails to write to PKCS #11 PAL.
+ *
+ */
+void test_pkcs11_C_CreateObjectSHA256HMACKeyPalFailure( void )
+{
+    CK_RV xResult = CKR_OK;
+    CK_SESSION_HANDLE xSession = CK_INVALID_HANDLE;
+    CK_KEY_TYPE xKeyType = CKK_SHA256_HMAC;
+    CK_OBJECT_CLASS xKeyClass = CKO_SECRET_KEY;
+    CK_BBOOL xTrue = CK_TRUE;
+    CK_OBJECT_HANDLE xObject = CK_INVALID_HANDLE;
+    CK_BYTE pcLabel[] = pkcs11configLABEL_HMAC_KEY;
+
+    CK_BYTE pxKeyValue[] = "abcdabcdabcdabcdabcdabcdabcdabcd";
+
+    CK_ATTRIBUTE xSHA256HMACTemplate[] =
+    {
+        { CKA_CLASS,    &xKeyClass, sizeof( CK_OBJECT_CLASS ) },
+        { CKA_KEY_TYPE, &xKeyType,  sizeof( CK_KEY_TYPE )     },
+        { CKA_LABEL,    pcLabel,    sizeof( pcLabel ) - 1     },
+        { CKA_TOKEN,    &xTrue,     sizeof( CK_BBOOL )        },
+        { CKA_SIGN,     &xTrue,     sizeof( CK_BBOOL )        },
+        { CKA_VERIFY,   &xTrue,     sizeof( CK_BBOOL )        },
+        { CKA_VALUE,    pxKeyValue, sizeof( pxKeyValue ) - 1  }
+    };
+
+    prvCommonInitStubs();
+
+    if( TEST_PROTECT() )
+    {
+        PKCS11_PAL_SaveObject_IgnoreAndReturn( 0 );
+        xResult = C_CreateObject( xSession,
+                                  ( CK_ATTRIBUTE_PTR ) &xSHA256HMACTemplate,
+                                  sizeof( xSHA256HMACTemplate ) / sizeof( CK_ATTRIBUTE ),
+                                  &xObject );
+
+        TEST_ASSERT_EQUAL( CKR_DEVICE_MEMORY, xResult );
+    }
+
+    prvCommonDeinitStubs();
+}
+
+/*!
+ * @brief C_CreateObject Creating a SHA256-HMAC invalid HMAC key type.
+ *
+ */
+void test_pkcs11_C_CreateObjectSHA256HMACKeyInvalidKeyType( void )
+{
+    CK_RV xResult = CKR_OK;
+    CK_SESSION_HANDLE xSession = CK_INVALID_HANDLE;
+    CK_KEY_TYPE xKeyType = CKK_MD5_HMAC;
+    CK_OBJECT_CLASS xKeyClass = CKO_SECRET_KEY;
+    CK_BBOOL xTrue = CK_TRUE;
+    CK_OBJECT_HANDLE xObject = CK_INVALID_HANDLE;
+    CK_BYTE pcLabel[] = pkcs11configLABEL_HMAC_KEY;
+
+    CK_BYTE pxKeyValue[] = "abcdabcdabcdabcdabcdabcdabcdabcd";
+
+    CK_ATTRIBUTE xSHA256HMACTemplate[] =
+    {
+        { CKA_CLASS,    &xKeyClass, sizeof( CK_OBJECT_CLASS ) },
+        { CKA_KEY_TYPE, &xKeyType,  sizeof( CK_KEY_TYPE )     },
+        { CKA_LABEL,    pcLabel,    sizeof( pcLabel ) - 1     },
+        { CKA_TOKEN,    &xTrue,     sizeof( CK_BBOOL )        },
+        { CKA_SIGN,     &xTrue,     sizeof( CK_BBOOL )        },
+        { CKA_VERIFY,   &xTrue,     sizeof( CK_BBOOL )        },
+        { CKA_VALUE,    pxKeyValue, sizeof( pxKeyValue ) - 1  }
+    };
+
+    prvCommonInitStubs();
+
+    if( TEST_PROTECT() )
+    {
+        PKCS11_PAL_SaveObject_IgnoreAndReturn( 1 );
+        mock_osal_mutex_lock_IgnoreAndReturn( 0 );
+        mock_osal_mutex_unlock_IgnoreAndReturn( 0 );
+        xResult = C_CreateObject( xSession,
+                                  ( CK_ATTRIBUTE_PTR ) &xSHA256HMACTemplate,
+                                  sizeof( xSHA256HMACTemplate ) / sizeof( CK_ATTRIBUTE ),
+                                  &xObject );
+
+        TEST_ASSERT_EQUAL( CKR_MECHANISM_INVALID, xResult );
+    }
+
+    prvCommonDeinitStubs();
+}
+
 /* ======================  TESTING C_GetAttributeValue  ============================ */
 
 /*!


### PR DESCRIPTION
Adds support for importing a SHA256-HMAC key.

1. Updates System test.
2. Updates unit tests.
3. Updates POSIX PAL for HMAC key support.