### PR TITLE
Add a README snippet outlining the purpose of corePKCS11

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ For example, FreeRTOS AWS reference integrations use a small subset of the PKCS 
 
 The Cryptoki or PKCS #11 standard defines a platform-independent API to manage and use cryptographic tokens. The name, "PKCS #11", is used interchangeably to refer to the API itself and the standard which defines it.
 
-This repository contains a software based mock implementation of the PKCS #11 interface (API) that uses the cryptographic functionality provided by mbedtls. Using a software mock to enables rapid development and flexibility, but it is expected that the mock be replaced by an implementation specific to your chosen secure key storage in production. 
+This repository contains a software based mock implementation of the PKCS #11 interface (API) that uses the cryptographic functionality provided by Mbed TLS. Using a software mock enables rapid development and flexibility, but it is expected that the mock be replaced by an implementation specific to your chosen secure key storage in production devices. 
 
 Only a subset of the PKCS #11 standard is implemented, with a focus on operations involving asymmetric keys, random number generation, and hashing. 
 
@@ -22,10 +22,9 @@ See memory requirements for the latest release [here](https://docs.aws.amazon.co
 # Purpose
 
 Generally vendors for secure cryptoprocessors such as Trusted Platform Module ([TPM](https://en.wikipedia.org/wiki/Trusted_Platform_Module)), Hardware Security Module ([HSM](https://en.wikipedia.org/wiki/Hardware_security_module)), Secure Element, or any other type of secure hardware enclave, distribute a PKCS #11 implementation with the hardware. 
-The purpose of this software only mock is therefore to provide a PKCS #11 implementation that allows for rapid prototyping and development before switching to a cryptoprocessor specific PKCS #11 implementation in production devices.
+The purpose of the corePKCS11 software only mock library is therefore to provide a non hardware specific PKCS #11 implementation that allows for rapid prototyping and development before switching to a cryptoprocessor specific PKCS #11 implementation in production devices.
 
-Since the PKCS #11 interface is defined as part of the PKCS #11 [specification](https://docs.oasis-open.org/pkcs11/pkcs11-base/v2.40/os/pkcs11-base-v2.40-os.html) replacing this library with another implementation 
-should require little porting effort, as the interface will not change. The system tests distributed in this repository can be leveraged to verify the behavior of a different implementation is similar to corePKCS11.
+Since the PKCS #11 interface is defined as part of the PKCS #11 [specification](https://docs.oasis-open.org/pkcs11/pkcs11-base/v2.40/os/pkcs11-base-v2.40-os.html) replacing this library with another implementation should require little porting effort, as the interface will not change. The system tests distributed in this repository can be leveraged to verify the behavior of a different implementation is similar to corePKCS11.
 
 ## Building Unit Tests.
 

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ See memory requirements for the latest release [here](https://docs.aws.amazon.co
 
 # Purpose
 
-Generally vendors for secure cryptoprocessors such as TPM, HSM, Secure Element, or any other type of secure hardware enclave, distribute a PKCS #11 implementation with the hardware. 
+Generally vendors for secure cryptoprocessors such as Trusted Platform Module ([TPM](https://en.wikipedia.org/wiki/Trusted_Platform_Module)), Hardware Security Module ([HSM](https://en.wikipedia.org/wiki/Hardware_security_module)), Secure Element, or any other type of secure hardware enclave, distribute a PKCS #11 implementation with the hardware. 
 The purpose of this software only mock is therefore to provide a PKCS #11 implementation that allows for rapid prototyping and development before switching to a cryptoprocessor specific PKCS #11 implementation in production devices.
 
 Since the PKCS #11 interface is defined as part of the PKCS #11 [specification](https://docs.oasis-open.org/pkcs11/pkcs11-base/v2.40/os/pkcs11-base-v2.40-os.html) replacing this library with another implementation 

--- a/README.md
+++ b/README.md
@@ -1,11 +1,11 @@
 # corePKCS11 Library 
+[PKCS #11](https://en.wikipedia.org/wiki/PKCS_11) is a standardised and widely used API for manipulating common cryptographic objects. It is important because the functions it specifies allow application software to use, create, modify, and delete cryptographic objects, without ever exposing those objects to the application’s memory. 
+For example, FreeRTOS AWS reference integrations use a small subset of the PKCS #11 API to, among other things, access the secret (private) key necessary to create a network connection that is authenticated and secured by the [Transport Layer Security (TLS)](https://en.wikipedia.org/wiki/Transport_Layer_Security) protocol – without the application ever ‘seeing’ the key.
+
 
 The Cryptoki or PKCS #11 standard defines a platform-independent API to manage and use cryptographic tokens. The name, "PKCS #11", is used interchangeably to refer to the API itself and the standard which defines it.
 
-The PKCS #11 API is useful for writing software without taking a dependency on any particular implementation or hardware. By writing against the PKCS #11 standard interface, code can be used interchangeably with multiple algorithms, implementations and hardware. 
-
 This repository contains a software based implementation of the PKCS #11 interface (API)  to enable rapid development and flexibility when developing applications that rely on cryptographic operations.
-
 Only a subset of the PKCS #11 standard is implemented, with a focus on operations involving asymmetric keys, random number generation, and hashing. 
 
 The targeted use cases include certificate and key management for TLS authentication and code-sign signature verification, on small embedded devices.

--- a/README.md
+++ b/README.md
@@ -1,5 +1,9 @@
 # corePKCS11 Library 
 
+The Cryptoki or PKCS #11 standard defines a platform-independent API to manage and use cryptographic tokens. The name, "PKCS #11", is used interchangeably to refer to the API itself and the standard which defines it.
+
+The PKCS #11 API is useful for writing software without taking a dependency on any particular implementation or hardware. By writing against the PKCS #11 standard interface, code can have compatibility and flexibility with multiple algorithms, implementations and hardware. 
+
 This repository contains a software based implementation of the PKCS #11 interface (API)  to enable rapid development and flexibility when developing  applications that rely on cryptographic operations.
 
 Only a subset of the PKCS #11 standard is implemented, with a focus on operations involving asymmetric keys, random number generation, and hashing. 
@@ -61,6 +65,19 @@ git submodule update --checkout --init --recursive test/unit-test/CMock
 ## Reference examples
 
 The FreeRTOS-Labs repository contains demos using the PKCS #11 library [here](https://github.com/FreeRTOS/FreeRTOS-Labs/tree/master/FreeRTOS-Plus/Demo/FreeRTOS_Plus_PKCS11_Windows_Simulator/examples) using FreeRTOS on the Windows simulator platform. These can be used as reference examples for the library API.
+
+## Porting Guide
+Documentation for porting corePKCS11 to a new platform can be found on the AWS [docs](https://docs.aws.amazon.com/freertos/latest/portingguide/afr-porting-pkcs.html) web page.
+
+corePKCS11 is not meant to be ported to projects that have a TPM, HSM, or other hardware for offloading crypto-processing. This library is specifically meant to be used for development and prototyping.
+
+
+## Related Example Implementations
+These projects implement the PKCS #11 interface on real hardware and have similar behavior to corePKCS11. It is preferred to use these, over corePKCS11, as they allow for offloading Cryptography to separate hardware.
+
+* ARM's [Platform Security Architecture](https://github.com/Linaro/freertos-pkcs11-psa). 
+* Microchip's [cryptoauthlib](https://github.com/MicrochipTech/cryptoauthlib). 
+* Infineon's [Optiga Trust X](https://github.com/aws/amazon-freertos/blob/master/vendors/infineon/secure_elements/pkcs11/iot_pkcs11_trustx.c). 
 
 ## Generating documentation
 

--- a/README.md
+++ b/README.md
@@ -14,6 +14,17 @@ See memory requirements for the latest release [here](https://docs.aws.amazon.co
 
 **corePKCS11 v3.0.0 [source code](https://github.com/FreeRTOS/corePKCS11/tree/v3.0.0/source) is part of the [FreeRTOS 202012.00 LTS](https://github.com/FreeRTOS/FreeRTOS-LTS/tree/202012.00-LTS) release.**
 
+# Purpose
+
+The purpose of this library is to provide a PKCS #11 implementation that allows for rapid prototyping and developing. Once a secure cryptoprocessor is selected, this library must be replaced with a PKCS #11 implementation that abstracts
+said cryptoprocessor.
+
+Since the PKCS #11 interface is defined as part of the PKCS #11 [specification](https://docs.oasis-open.org/pkcs11/pkcs11-base/v2.40/os/pkcs11-base-v2.40-os.html) replacing this library with another implementation 
+should require little porting effort, as the interface will not change. The system tests distributed in this repository can be leveraged to verify the behavior of a different implementation is similar to corePKCS11.
+
+Generally vendors for secure cryptoprocessors such as TPM, HSM, Secure Element, or any other type of secure hardware enclave, distribute a PKCS #11 implementation with the hardware. 
+The recommendation is to use a secure cryptoprocessor, and replace corePKCS11 with an implementation compatible with said cryptoprocessor.
+
 ## Building Unit Tests.
 
 ### PKCS Config File

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ The Cryptoki or PKCS #11 standard defines a platform-independent API to manage a
 
 The PKCS #11 API is useful for writing software without taking a dependency on any particular implementation or hardware. By writing against the PKCS #11 standard interface, code can be used interchangeably with multiple algorithms, implementations and hardware. 
 
-This repository contains a software based implementation of the PKCS #11 interface (API)  to enable rapid development and flexibility when developing  applications that rely on cryptographic operations.
+This repository contains a software based implementation of the PKCS #11 interface (API)  to enable rapid development and flexibility when developing applications that rely on cryptographic operations.
 
 Only a subset of the PKCS #11 standard is implemented, with a focus on operations involving asymmetric keys, random number generation, and hashing. 
 
@@ -20,7 +20,7 @@ See memory requirements for the latest release [here](https://docs.aws.amazon.co
 
 # Purpose
 
-The purpose of this library is to provide a PKCS #11 implementation that allows for rapid prototyping and developing. Once a secure cryptoprocessor is selected, this library must be replaced with a PKCS #11 implementation that abstracts
+The purpose of this library is to provide a PKCS #11 implementation that allows for rapid prototyping and development. Once a secure cryptoprocessor is selected, this library must be replaced with a PKCS #11 implementation that abstracts
 said cryptoprocessor.
 
 Since the PKCS #11 interface is defined as part of the PKCS #11 [specification](https://docs.oasis-open.org/pkcs11/pkcs11-base/v2.40/os/pkcs11-base-v2.40-os.html) replacing this library with another implementation 

--- a/README.md
+++ b/README.md
@@ -5,7 +5,8 @@ For example, FreeRTOS AWS reference integrations use a small subset of the PKCS 
 
 The Cryptoki or PKCS #11 standard defines a platform-independent API to manage and use cryptographic tokens. The name, "PKCS #11", is used interchangeably to refer to the API itself and the standard which defines it.
 
-This repository contains a software based implementation of the PKCS #11 interface (API)  to enable rapid development and flexibility when developing applications that rely on cryptographic operations.
+This repository contains a software based mock implementation of the PKCS #11 interface (API) that uses the cryptographic functionality provided by mbedtls. Using a software mock to enables rapid development and flexibility, but it is expected that the mock be replaced by an implementation specific to your chosen secure key storage in production. 
+
 Only a subset of the PKCS #11 standard is implemented, with a focus on operations involving asymmetric keys, random number generation, and hashing. 
 
 The targeted use cases include certificate and key management for TLS authentication and code-sign signature verification, on small embedded devices.
@@ -20,14 +21,11 @@ See memory requirements for the latest release [here](https://docs.aws.amazon.co
 
 # Purpose
 
-The purpose of this library is to provide a PKCS #11 implementation that allows for rapid prototyping and development. Once a secure cryptoprocessor is selected, this library must be replaced with a PKCS #11 implementation that abstracts
-said cryptoprocessor.
+Generally vendors for secure cryptoprocessors such as TPM, HSM, Secure Element, or any other type of secure hardware enclave, distribute a PKCS #11 implementation with the hardware. 
+The purpose of this software only mock is therefore to provide a PKCS #11 implementation that allows for rapid prototyping and development before switching to a cryptoprocessor specific PKCS #11 implementation in production devices.
 
 Since the PKCS #11 interface is defined as part of the PKCS #11 [specification](https://docs.oasis-open.org/pkcs11/pkcs11-base/v2.40/os/pkcs11-base-v2.40-os.html) replacing this library with another implementation 
 should require little porting effort, as the interface will not change. The system tests distributed in this repository can be leveraged to verify the behavior of a different implementation is similar to corePKCS11.
-
-Generally vendors for secure cryptoprocessors such as TPM, HSM, Secure Element, or any other type of secure hardware enclave, distribute a PKCS #11 implementation with the hardware. 
-The recommendation is to use a secure cryptoprocessor, and replace corePKCS11 with an implementation compatible with said cryptoprocessor.
 
 ## Building Unit Tests.
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 The Cryptoki or PKCS #11 standard defines a platform-independent API to manage and use cryptographic tokens. The name, "PKCS #11", is used interchangeably to refer to the API itself and the standard which defines it.
 
-The PKCS #11 API is useful for writing software without taking a dependency on any particular implementation or hardware. By writing against the PKCS #11 standard interface, code can have compatibility and flexibility with multiple algorithms, implementations and hardware. 
+The PKCS #11 API is useful for writing software without taking a dependency on any particular implementation or hardware. By writing against the PKCS #11 standard interface, code can be used interchangeably with multiple algorithms, implementations and hardware. 
 
 This repository contains a software based implementation of the PKCS #11 interface (API)  to enable rapid development and flexibility when developing  applications that rely on cryptographic operations.
 


### PR DESCRIPTION
The intention of this section is to specify the reasons for the creation of corePKCS11, and how it fits in the development process of a product.