### PR TITLE
Fix system test output suppresion.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,7 +25,7 @@ jobs:
       - name: System Tests
         run: |
           cd build/
-          ctest -E system --output-on-failure
+          ctest --output-on-failure
   unittest:
     runs-on: ubuntu-latest
     steps:
@@ -44,7 +44,7 @@ jobs:
       - name: Unit Tests
         run: |
           cd build/
-          ctest -E system --output-on-failure
+          ctest --output-on-failure
           cd ..
       - name: Coverage
         run: |


### PR DESCRIPTION
The `ctest -E` command was suppressing output, as it is an ignore regex.