### PR TITLE
AES CMAC

### DIFF
--- a/docs/doxygen/include/size_table.html
+++ b/docs/doxygen/include/size_table.html
@@ -19,12 +19,12 @@
     </tr>
     <tr>
         <td>core_pkcs11_mbedtls.c</td>
-        <td><center>7.9K</center></td>
-        <td><center>6.7K</center></td>
+        <td><center>8.5K</center></td>
+        <td><center>7.0K</center></td>
     </tr>
     <tr>
         <td><b>Total estimates</b></td>
-        <td><b><center>9.2K</center></b></td>
-        <td><b><center>7.8K</center></b></td>
+        <td><b><center>9.8K</center></b></td>
+        <td><b><center>8.1K</center></b></td>
     </tr>
 </table>

--- a/lexicon.txt
+++ b/lexicon.txt
@@ -1,3 +1,4 @@
+aes
 alg
 algorithmidentifier
 algorithmidentifiersequence
@@ -23,6 +24,7 @@ cko
 ckr
 closeallsessions
 closesession
+cmac
 codesignkey
 colspan
 com
@@ -61,6 +63,7 @@ digestinit
 digestkey
 digestupdate
 drbg
+eawscmacsecretkey
 eawscodesigningkey
 eawsdevicecertificate
 eawsdeviceprivatekey
@@ -308,6 +311,8 @@ www
 xapphandle
 xbyte
 xcertificatetype
+xcmackeyhandle
+xcmacsecretcontext
 xclass
 xfindobjectlabellen
 xfindobjectwithlabelandclass

--- a/source/include/core_pkcs11.h
+++ b/source/include/core_pkcs11.h
@@ -95,7 +95,7 @@
  * @ingroup pkcs11_wrapper_macros
  * @brief Length of a CMAC signature, in bytes.
  */
-#define pkcs11AES_CMAC_SIGNATURE_LENGTH      32UL
+#define pkcs11AES_CMAC_SIGNATURE_LENGTH      16UL
 
 /**
  * @ingroup pkcs11_wrapper_macros

--- a/source/include/core_pkcs11.h
+++ b/source/include/core_pkcs11.h
@@ -93,6 +93,12 @@
 
 /**
  * @ingroup pkcs11_wrapper_macros
+ * @brief Length of a CMAC signarutre, in bytes.
+ */
+#define pkcs11AES_CMAC_SIGNATURE_LENGTH           32UL
+
+/**
+ * @ingroup pkcs11_wrapper_macros
  * @brief Length of a curve P-256 ECDSA signature, in bytes.
  * PKCS #11 EC signatures are represented as a 32-bit R followed
  * by a 32-bit S value, and not ASN.1 encoded.

--- a/source/include/core_pkcs11.h
+++ b/source/include/core_pkcs11.h
@@ -95,7 +95,7 @@
  * @ingroup pkcs11_wrapper_macros
  * @brief Length of a CMAC signarutre, in bytes.
  */
-#define pkcs11AES_CMAC_SIGNATURE_LENGTH           32UL
+#define pkcs11AES_CMAC_SIGNATURE_LENGTH      32UL
 
 /**
  * @ingroup pkcs11_wrapper_macros

--- a/source/include/core_pkcs11.h
+++ b/source/include/core_pkcs11.h
@@ -93,7 +93,7 @@
 
 /**
  * @ingroup pkcs11_wrapper_macros
- * @brief Length of a CMAC signarutre, in bytes.
+ * @brief Length of a CMAC signature, in bytes.
  */
 #define pkcs11AES_CMAC_SIGNATURE_LENGTH      32UL
 

--- a/source/portable/mbedtls/core_pkcs11_mbedtls.c
+++ b/source/portable/mbedtls/core_pkcs11_mbedtls.c
@@ -3886,6 +3886,107 @@ static CK_RV prvSignInitSHA256HMAC( P11Session_t * pxSession,
 }
 
 /**
+ * @brief Helper function for cleaning up an CMAC verify operation.
+ * @param[in] pxSession  Pointer to a valid PKCS #11 session.
+ */
+static void prvCMACCleanUp( P11Session_t * pxSession )
+{
+    pxSession->xHMACKeyHandle = CK_INVALID_HANDLE;
+    mbedtls_cipher_free( &pxSession->xCMACSecretContext );
+}
+
+/**
+ * @brief Helper function for initializing a AES-CMAC operation.
+ * @param[in] pxSession         Pointer to a valid PKCS #11 session.
+ * @param[in] hKey              CMAC secret key handle.
+ * @param[in] pucKeyData        CMAC secret key data.
+ * @param[in] ulKeyDataLength   CMAC key Size.
+ */
+static CK_RV prvInitAESCMAC( P11Session_t * pxSession,
+                             CK_OBJECT_HANDLE hKey,
+                             CK_BYTE_PTR pucKeyData,
+                             CK_ULONG ulKeyDataLength )
+{
+    CK_RV xResult = CKR_OK;
+    int32_t lMbedTLSResult = -1;
+    const mbedtls_cipher_info_t * pxCipherInfo = NULL;
+
+    mbedtls_cipher_init( &pxSession->xCMACSecretContext );
+    pxCipherInfo = mbedtls_cipher_info_from_type( MBEDTLS_CIPHER_AES_128_ECB );
+
+    if( pxCipherInfo == NULL )
+    {
+        LogError( ( "Failed to initialize AESCMAC operation. "
+                    "mbedtls_ciphre_info_from_type failed. Consider "
+                    "double checking the mbedtls_md_type_t object "
+                    "that was used." ) );
+        xResult = CKR_FUNCTION_FAILED;
+        prvCMACCleanUp( pxSession );
+    }
+
+    if( xResult == CKR_OK )
+    {
+        lMbedTLSResult = mbedtls_cipher_setup( &pxSession->xCMACSecretContext,
+                                               pxCipherInfo );
+
+        if( lMbedTLSResult != 0 )
+        {
+            LogError( ( "Failed to initialize AESCMAC operation. "
+                        "mbedtls_cipher_setup failed: mbed TLS error = %s : %s.",
+                        mbedtlsHighLevelCodeOrDefault( lMbedTLSResult ),
+                        mbedtlsLowLevelCodeOrDefault( lMbedTLSResult ) ) );
+            prvCMACCleanUp( pxSession );
+            xResult = CKR_KEY_HANDLE_INVALID;
+        }
+    }
+
+    if( xResult == CKR_OK )
+    {
+        lMbedTLSResult = mbedtls_cipher_cmac_starts( &pxSession->xCMACSecretContext,
+                                                     pucKeyData, 8 * ulKeyDataLength );
+
+        if( lMbedTLSResult != 0 )
+        {
+            LogError( ( "Failed to initialize AESCMAC operation. "
+                        "mbedtls_md_setup failed: mbed TLS error = %s : %s.",
+                        mbedtlsHighLevelCodeOrDefault( lMbedTLSResult ),
+                        mbedtlsLowLevelCodeOrDefault( lMbedTLSResult ) ) );
+            prvCMACCleanUp( pxSession );
+            xResult = CKR_KEY_HANDLE_INVALID;
+        }
+    }
+
+    if( xResult == CKR_OK )
+    {
+        pxSession->xHMACKeyHandle = hKey;
+    }
+
+    return xResult;
+}
+
+/**
+ * @brief Helper function for initializing a sign operation for AES-CMAC.
+ * @param[in] pxSession         Pointer to a valid PKCS #11 session.
+ * @param[in] hKey              CMAC secret key handle.
+ * @param[in] pucKeyData        CMAC secret key data.
+ * @param[in] ulKeyDataLength   CMAC key Size.
+ */
+static CK_RV prvSignInitAESCMAC( P11Session_t * pxSession,
+                                 CK_OBJECT_HANDLE hKey,
+                                 CK_BYTE_PTR pucKeyData,
+                                 CK_ULONG ulKeyDataLength )
+{
+    CK_RV xResult = CKR_OK;
+
+    xResult = prvInitAESCMAC( pxSession,
+                              hKey,
+                              pucKeyData,
+                              ulKeyDataLength );
+
+    return xResult;
+}
+
+/**
  * @brief Helper function for cleaning up a sign operation for an EC or RSA key.
  * @param[in] pxSession   Pointer to a valid PKCS #11 session.
  */
@@ -4080,6 +4181,19 @@ CK_DECLARE_FUNCTION( CK_RV, C_SignInit )( CK_SESSION_HANDLE hSession,
                     if( ( pxSession->xHMACKeyHandle == CK_INVALID_HANDLE ) || ( pxSession->xHMACKeyHandle != hKey ) )
                     {
                         xResult = prvSignInitSHA256HMAC( pxSession, hKey, pucKeyData, ulKeyDataLength );
+                    }
+                    else
+                    {
+                        /* The correct credentials are already initialized. */
+                    }
+
+                    break;
+
+                case CKM_AES_CMAC:
+
+                    if( ( pxSession->xHMACKeyHandle == CK_INVALID_HANDLE ) || ( pxSession->xHMACKeyHandle != hKey ) )
+                    {
+                        xResult = prvSignInitAESCMAC( pxSession, hKey, pucKeyData, ulKeyDataLength );
                     }
                     else
                     {
@@ -4347,16 +4461,6 @@ static CK_RV prvVerifyInitSHA256HMAC( P11Session_t * pxSession,
 }
 
 /**
- * @brief Helper function for cleaning up an CMAC verify operation.
- * @param[in] pxSession  Pointer to a valid PKCS #11 session.
- */
-static void prvVerifyInitCMACCleanUp( P11Session_t * pxSession )
-{
-    pxSession->xHMACKeyHandle = CK_INVALID_HANDLE;
-    mbedtls_cipher_free( &pxSession->xCMACSecretContext );
-}
-
-/**
  * @brief Helper function for initializing a verify operation for AES-CMAC.
  * @param[in] pxSession         Pointer to a valid PKCS #11 session.
  * @param[in] hKey              CMAC secret key handle.
@@ -4369,58 +4473,11 @@ static CK_RV prvVerifyInitAESCMAC( P11Session_t * pxSession,
                                    CK_ULONG ulKeyDataLength )
 {
     CK_RV xResult = CKR_OK;
-    int32_t lMbedTLSResult = -1;
-    const mbedtls_cipher_info_t * pxCipherInfo = NULL;
 
-    mbedtls_cipher_init( &pxSession->xCMACSecretContext );
-    pxCipherInfo = mbedtls_cipher_info_from_type( MBEDTLS_CIPHER_AES_128_ECB );
-
-    if( pxCipherInfo == NULL )
-    {
-        LogError( ( "Failed to initialize verify operation. "
-                    "mbedtls_ciphre_info_from_type failed. Consider "
-                    "double checking the mbedtls_md_type_t object "
-                    "that was used." ) );
-        xResult = CKR_FUNCTION_FAILED;
-        prvVerifyInitCMACCleanUp( pxSession );
-    }
-
-    if( xResult == CKR_OK )
-    {
-        lMbedTLSResult = mbedtls_cipher_setup( &pxSession->xCMACSecretContext,
-                                               pxCipherInfo );
-
-        if( lMbedTLSResult != 0 )
-        {
-            LogError( ( "Failed to initialize verify operation. "
-                        "mbedtls_cipher_setup failed: mbed TLS error = %s : %s.",
-                        mbedtlsHighLevelCodeOrDefault( lMbedTLSResult ),
-                        mbedtlsLowLevelCodeOrDefault( lMbedTLSResult ) ) );
-            prvVerifyInitCMACCleanUp( pxSession );
-            xResult = CKR_KEY_HANDLE_INVALID;
-        }
-    }
-
-    if( xResult == CKR_OK )
-    {
-        lMbedTLSResult = mbedtls_cipher_cmac_starts( &pxSession->xCMACSecretContext,
-                                                     pucKeyData, 8 * ulKeyDataLength );
-
-        if( lMbedTLSResult != 0 )
-        {
-            LogError( ( "Failed to initialize verify operation. "
-                        "mbedtls_md_setup failed: mbed TLS error = %s : %s.",
-                        mbedtlsHighLevelCodeOrDefault( lMbedTLSResult ),
-                        mbedtlsLowLevelCodeOrDefault( lMbedTLSResult ) ) );
-            prvVerifyInitCMACCleanUp( pxSession );
-            xResult = CKR_KEY_HANDLE_INVALID;
-        }
-    }
-
-    if( xResult == CKR_OK )
-    {
-        pxSession->xHMACKeyHandle = hKey;
-    }
+    xResult = prvInitAESCMAC( pxSession,
+                              hKey,
+                              pucKeyData,
+                              ulKeyDataLength );
 
     return xResult;
 }

--- a/source/portable/mbedtls/core_pkcs11_mbedtls.c
+++ b/source/portable/mbedtls/core_pkcs11_mbedtls.c
@@ -4309,6 +4309,12 @@ CK_DECLARE_FUNCTION( CK_RV, C_Sign )( CK_SESSION_HANDLE hSession,
             xExpectedInputLength = pkcs11SHA256_DIGEST_LENGTH;
             xHashType = MBEDTLS_MD_SHA256;
         }
+        else if( pxSessionObj->xOperationSignMechanism == CKM_AES_CMAC )
+        {
+            xSignatureLength = pkcs11AES_CMAC_SIGNATURE_LENGTH;
+            xExpectedInputLength = pkcs11AES_CMAC_SIGNATURE_LENGTH;
+            xHashType = MBEDTLS_CIPHER_AES_128_ECB;
+        }       
         else
         {
             LogError( ( "Failed sign operation. The sign operation was not "
@@ -4347,6 +4353,18 @@ CK_DECLARE_FUNCTION( CK_RV, C_Sign )( CK_SESSION_HANDLE hSession,
                         }
 
                         pxSessionObj->xHMACKeyHandle = CK_INVALID_HANDLE;
+                    }
+                    else if( pxSessionObj->xOperationSignMechanism == CKM_AES_CMAC )
+                    {
+                        lMbedTLSResult = mbedtls_cipher_cmac_update( &pxSessionObj->xCMACSecretContext, pData, ulDataLen);
+
+                        if( lMbedTLSResult == 0 )
+                        {
+                            lMbedTLSResult = mbedtls_cipher_cmac_finish( &pxSessionObj->xCMACSecretContext, pxSignatureBuffer );
+                        }
+                        
+                        pxSessionObj->xHMACKeyHandle = CK_INVALID_HANDLE;
+
                     }
                     else
                     {

--- a/source/portable/mbedtls/core_pkcs11_mbedtls.c
+++ b/source/portable/mbedtls/core_pkcs11_mbedtls.c
@@ -232,7 +232,7 @@
  * @ingroup pkcs11_macros
  * @brief Private define for minimum AES-CMAC key size, in bytes.
  */
-#define PKCS11_AES_CMAC_MIN_SIZE        ( 16UL )
+#define PKCS11_AES_CMAC_MIN_SIZE           ( 16UL )
 
 /**
  * @ingroup pkcs11_macros
@@ -2538,6 +2538,7 @@ static CK_RV prvCMACKeyAttParse( const CK_ATTRIBUTE * pxAttribute,
             break;
 
         case ( CKA_VALUE ):
+
             if( ( pxAttribute->ulValueLen >= PKCS11_AES_CMAC_MIN_SIZE ) &&
                 ( pxAttribute->pValue != NULL ) )
             {
@@ -2736,8 +2737,8 @@ static CK_RV prvCreateSecretKey( CK_ATTRIBUTE * pxTemplate,
     }
     else if( xKeyType == CKK_AES )
     {
-        xResult = prvCreateAESCMAC( pxTemplate, 
-                                    ulCount, 
+        xResult = prvCreateAESCMAC( pxTemplate,
+                                    ulCount,
                                     pxObject );
     }
     else
@@ -4354,7 +4355,7 @@ static CK_RV prvVerifyInitSHA256HMAC( P11Session_t * pxSession,
 static void prvVerifyInitCMACCleanUp( P11Session_t * pxSession )
 {
     pxSession->xHMACKeyHandle = CK_INVALID_HANDLE;
-    mbedtls_cipher_free(&pxSession->xCMACSecretContext);
+    mbedtls_cipher_free( &pxSession->xCMACSecretContext );
 }
 
 /**
@@ -4373,7 +4374,7 @@ static CK_RV prvVerifyInitAESCMAC( P11Session_t * pxSession,
     int32_t lMbedTLSResult = -1;
     const mbedtls_cipher_info_t * pxCipherInfo = NULL;
 
-    mbedtls_cipher_init(&pxSession->xCMACSecretContext);
+    mbedtls_cipher_init( &pxSession->xCMACSecretContext );
     pxCipherInfo = mbedtls_cipher_info_from_type( MBEDTLS_CIPHER_AES_128_ECB );
 
     if( pxCipherInfo == NULL )
@@ -4635,12 +4636,14 @@ CK_DECLARE_FUNCTION( CK_RV, C_VerifyInit )( CK_SESSION_HANDLE hSession,
                     }
 
                     break;
-                
+
                 case CKM_AES_CMAC:
+
                     if( ( pxSession->xHMACKeyHandle == CK_INVALID_HANDLE ) || ( pxSession->xCMACKeyHandle != hKey ) )
                     {
                         xResult = prvVerifyInitAESCMAC( pxSession, hKey, pucKeyData, ulKeyDataLength );
                     }
+
                     break;
 
                 default:
@@ -4910,7 +4913,7 @@ CK_DECLARE_FUNCTION( CK_RV, C_Verify )( CK_SESSION_HANDLE hSession,
             else if( pxSessionObj->xOperationVerifyMechanism == CKM_AES_CMAC )
             {
                 lMbedTLSResult = mbedtls_cipher_cmac_update( &pxSessionObj->xCMACSecretContext, pData, ulDataLen );
-                
+
                 if( lMbedTLSResult != 0 )
                 {
                     xResult = CKR_SIGNATURE_INVALID;
@@ -4933,7 +4936,7 @@ CK_DECLARE_FUNCTION( CK_RV, C_Verify )( CK_SESSION_HANDLE hSession,
                     }
                     else
                     {
-                        // TODO: Verify output sizes and use appropriate 
+                        /* TODO: Verify output sizes and use appropriate */
                         if( 0 != memcmp( pxCMACBuffer, pSignature, MBEDTLS_AES_BLOCK_SIZE ) )
                         {
                             xResult = CKR_SIGNATURE_INVALID;

--- a/source/portable/mbedtls/core_pkcs11_mbedtls.c
+++ b/source/portable/mbedtls/core_pkcs11_mbedtls.c
@@ -2588,7 +2588,6 @@ static CK_RV prvCreateAESCMAC( CK_ATTRIBUTE * pxTemplate,
         xResult = CKR_ARGUMENTS_BAD;
     }
 
-    /* TODO: Why is this called "creating key" when the key already exists? Perhaps "load key"? */
     if( xResult == CKR_OK )
     {
         for( ulIndex = 0; ulIndex < ulCount; ulIndex++ )
@@ -2602,7 +2601,6 @@ static CK_RV prvCreateAESCMAC( CK_ATTRIBUTE * pxTemplate,
         }
     }
 
-    /* TODO: Check with Carl on what size checks are appropriate and where to source the size vars/macros */
     if( ( xResult == CKR_OK ) && ( pxSecretKeyValue != NULL ) )
     {
         xPalHandle = PKCS11_PAL_SaveObject( pxLabel,
@@ -4936,7 +4934,6 @@ CK_DECLARE_FUNCTION( CK_RV, C_Verify )( CK_SESSION_HANDLE hSession,
                     }
                     else
                     {
-                        /* TODO: Verify output sizes and use appropriate */
                         if( 0 != memcmp( pxCMACBuffer, pSignature, MBEDTLS_AES_BLOCK_SIZE ) )
                         {
                             xResult = CKR_SIGNATURE_INVALID;

--- a/source/portable/mbedtls/core_pkcs11_mbedtls.c
+++ b/source/portable/mbedtls/core_pkcs11_mbedtls.c
@@ -45,6 +45,7 @@
 #include "mbedtls/sha256.h"
 #include "mbedtls/platform.h"
 #include "mbedtls/threading.h"
+#include "mbedtls/cipher.h"
 
 /* Custom mbedtls utils include. */
 #include "mbedtls_error.h"
@@ -228,6 +229,12 @@
 
 /**
  * @ingroup pkcs11_macros
+ * @brief Private define for minimum AES-CMAC key size, in bytes.
+ */
+#define PKCS11_AES_CMAC_MIN_SIZE        ( 16UL )
+
+/**
+ * @ingroup pkcs11_macros
  * @brief Private define to inform mbedtls MD module to use an HMAC for the MD context.
  */
 #define PKCS11_USING_HMAC                  ( 1 )
@@ -297,6 +304,8 @@ typedef struct P11Session
     mbedtls_sha256_context xSHA256Context;       /**< @brief Context for in progress digest operation. */
     CK_OBJECT_HANDLE xHMACKeyHandle;             /**< @brief Object handle to the HMAC key. */
     mbedtls_md_context_t xHMACSecretContext;     /**< @brief Context for in progress HMAC operation. Set during C_SignInit or C_VerifyInit. */
+    CK_OBJECT_HANDLE xCMACKeyHandle;             /**< @brief Object handle to the CMAC key. */
+    mbedtls_cipher_context_t xCMACSecretContext; /**< @brief Context for in progress CMAC operation. Set during C_SignInit or C_VerifyInit. */
 } P11Session_t;
 
 /*-----------------------------------------------------------*/
@@ -2490,6 +2499,129 @@ static CK_RV prvCreateSHA256HMAC( CK_ATTRIBUTE * pxTemplate,
 }
 
 /**
+ * @brief Parses attribute values for a RSA Key.
+ */
+static CK_RV prvCMACKeyAttParse( const CK_ATTRIBUTE * pxAttribute,
+                                 CK_BYTE_PTR * ppxCmacKey,
+                                 CK_ULONG * pulCmacKeyLen )
+{
+    CK_RV xResult = CKR_OK;
+    /* See explanation in prvCheckValidSessionAndModule for this exception. */
+    /* coverity[misra_c_2012_rule_10_5_violation] */
+    CK_BBOOL xBool = ( CK_BBOOL ) CK_FALSE;
+
+    switch( pxAttribute->type )
+    {
+        case ( CKA_CLASS ):
+        case ( CKA_KEY_TYPE ):
+        case ( CKA_LABEL ):
+            /* Do nothing. These values were parsed previously. */
+            break;
+
+        case ( CKA_TOKEN ):
+        case ( CKA_VERIFY ):
+        case ( CKA_SIGN ):
+
+            if( pxAttribute->ulValueLen == sizeof( CK_BBOOL ) )
+            {
+                ( void ) memcpy( &xBool, pxAttribute->pValue, sizeof( CK_BBOOL ) );
+            }
+
+            /* See explanation in prvCheckValidSessionAndModule for this exception. */
+            /* coverity[misra_c_2012_rule_10_5_violation] */
+            if( xBool != ( CK_BBOOL ) CK_TRUE )
+            {
+                xResult = CKR_ATTRIBUTE_VALUE_INVALID;
+            }
+
+            break;
+
+        case ( CKA_VALUE ):
+            if( ( pxAttribute->ulValueLen >= PKCS11_AES_CMAC_MIN_SIZE ) &&
+                ( pxAttribute->pValue != NULL ) )
+            {
+                *ppxCmacKey = pxAttribute->pValue;
+                *pulCmacKeyLen = pxAttribute->ulValueLen;
+            }
+            else
+            {
+                LogError( ( "Failed to create SHA256-HMAC secret key. "
+                            "Key should be at least 32 bytes and/or non-NULL." ) );
+                xResult = CKR_ATTRIBUTE_VALUE_INVALID;
+            }
+
+            break;
+
+        default:
+            xResult = CKR_ATTRIBUTE_TYPE_INVALID;
+            break;
+    }
+
+    return xResult;
+}
+
+/**
+ * @brief Helper function for parsing AES-CMAC Key attribute templates
+ * for C_CreateObject.
+ * @param[in] pxTemplate templates to search for a key in.
+ * @param[in] ulCount length of templates array.
+ * @param[in] pxObject PKCS #11 object handle.
+ */
+static CK_RV prvCreateAESCMAC( CK_ATTRIBUTE * pxTemplate,
+                               CK_ULONG ulCount,
+                               CK_OBJECT_HANDLE_PTR pxObject )
+{
+    CK_RV xResult = CKR_OK;
+    uint32_t ulIndex;
+    CK_ATTRIBUTE_PTR pxLabel = NULL;
+    CK_BYTE_PTR pxSecretKeyValue = NULL;
+    CK_ULONG ulSecretKeyValueLen = 0;
+    CK_OBJECT_HANDLE xPalHandle = CK_INVALID_HANDLE;
+
+    prvGetLabel( &pxLabel, pxTemplate, ulCount );
+
+    if( pxLabel == NULL )
+    {
+        LogError( ( "Failed creating an AES key. Label was a NULL pointer." ) );
+        xResult = CKR_ARGUMENTS_BAD;
+    }
+
+    /* TODO: Why is this called "creating key" when the key already exists? Perhaps "load key"? */
+    if( xResult == CKR_OK )
+    {
+        for( ulIndex = 0; ulIndex < ulCount; ulIndex++ )
+        {
+            xResult = prvCMACKeyAttParse( &pxTemplate[ ulIndex ], &pxSecretKeyValue, &ulSecretKeyValueLen );
+
+            if( xResult != CKR_OK )
+            {
+                break;
+            }
+        }
+    }
+
+    /* TODO: Check with Carl on what size checks are appropriate and where to source the size vars/macros */
+    if( ( xResult == CKR_OK ) && ( pxSecretKeyValue != NULL ) )
+    {
+        xPalHandle = PKCS11_PAL_SaveObject( pxLabel,
+                                            pxSecretKeyValue,
+                                            ulSecretKeyValueLen );
+
+        if( xPalHandle == CK_INVALID_HANDLE )
+        {
+            LogError( ( "Failed saving CMAC secret key to flash. Failed to the PKCS #11 PAL." ) );
+            xResult = CKR_DEVICE_MEMORY;
+        }
+        else
+        {
+            xResult = prvAddObjectToList( xPalHandle, pxObject, pxLabel->pValue, pxLabel->ulValueLen );
+        }
+    }
+
+    return xResult;
+}
+
+/**
  * @brief Helper function for importing private keys using template
  * C_CreateObject.
  * @param[in] pxTemplate templates to search for a key in.
@@ -2601,11 +2733,17 @@ static CK_RV prvCreateSecretKey( CK_ATTRIBUTE * pxTemplate,
                                        ulCount,
                                        pxObject );
     }
+    else if( xKeyType == CKK_AES )
+    {
+        xResult = prvCreateAESCMAC( pxTemplate, 
+                                    ulCount, 
+                                    pxObject );
+    }
     else
     {
         LogError( ( "Failed to create a key. Tried to create a key with an "
                     "invalid or unknown mechanism. Only CKK_SHA256_HMAC is "
-                    "currently support." ) );
+                    "currently supported." ) );
         xResult = CKR_MECHANISM_INVALID;
     }
 
@@ -4208,6 +4346,19 @@ static CK_RV prvVerifyInitSHA256HMAC( P11Session_t * pxSession,
     return xResult;
 }
 
+static CK_RV prvVerifyInitAESCMAC( P11Session_t * pxSession,
+                                   CK_OBJECT_HANDLE hKey,
+                                   CK_BYTE_PTR pucKeyData,
+                                   CK_ULONG ulKeyDataLength )
+{
+    CK_RV xResult = CKR_OK;
+    int32_t lMbedTLSResult = -1;
+    const mbedtls_cipher_context_t * pxMdInfo = NULL;
+
+
+
+}
+
 /**
  * @brief Helper function for cleaning up a verify operation for an EC or RSA key.
  * @param[in] pxSession   Pointer to a valid PKCS #11 session.
@@ -4416,6 +4567,13 @@ CK_DECLARE_FUNCTION( CK_RV, C_VerifyInit )( CK_SESSION_HANDLE hSession,
                         xResult = prvVerifyInitSHA256HMAC( pxSession, hKey, pucKeyData, ulKeyDataLength );
                     }
 
+                    break;
+                
+                case CKM_AES_CMAC:
+                    if( ( pxSession->xHMACKeyHandle == CK_INVALID_HANDLE ) || ( pxSession->xCMACKeyHandle != hKey ) )
+                    {
+                        xResult = prvVerifyInitAESCMAC( pxSession, hKey, pucKeyData, ulKeyDataLength );
+                    }
                     break;
 
                 default:

--- a/source/portable/mbedtls/core_pkcs11_mbedtls.c
+++ b/source/portable/mbedtls/core_pkcs11_mbedtls.c
@@ -4376,7 +4376,7 @@ static CK_RV prvVerifyInitAESCMAC( P11Session_t * pxSession,
                     "double checking the mbedtls_md_type_t object "
                     "that was used." ) );
         xResult = CKR_FUNCTION_FAILED;
-        prvVerifyInitHMACCleanUp( pxSession );
+        prvVerifyInitCMACCleanUp( pxSession );
     }
 
     if( xResult == CKR_OK )

--- a/source/portable/mbedtls/core_pkcs11_mbedtls.c
+++ b/source/portable/mbedtls/core_pkcs11_mbedtls.c
@@ -4357,6 +4357,13 @@ static void prvVerifyInitCMACCleanUp( P11Session_t * pxSession )
     mbedtls_cipher_free(&pxSession->xCMACSecretContext);
 }
 
+/**
+ * @brief Helper function for initializing a verify operation for AES-CMAC.
+ * @param[in] pxSession         Pointer to a valid PKCS #11 session.
+ * @param[in] hKey              CMAC secret key handle.
+ * @param[in] pucKeyData        CMAC secret key data.
+ * @param[in] ulKeyDataLength   CMAC key Size.
+ */
 static CK_RV prvVerifyInitAESCMAC( P11Session_t * pxSession,
                                    CK_OBJECT_HANDLE hKey,
                                    CK_BYTE_PTR pucKeyData,

--- a/source/portable/mbedtls/core_pkcs11_mbedtls.c
+++ b/source/portable/mbedtls/core_pkcs11_mbedtls.c
@@ -45,7 +45,6 @@
 #include "mbedtls/sha256.h"
 #include "mbedtls/platform.h"
 #include "mbedtls/threading.h"
-#include "mbedtls/cipher.h"
 #include "mbedtls/cmac.h"
 
 /* Custom mbedtls utils include. */
@@ -3891,7 +3890,7 @@ static CK_RV prvSignInitSHA256HMAC( P11Session_t * pxSession,
  */
 static void prvCMACCleanUp( P11Session_t * pxSession )
 {
-    pxSession->xHMACKeyHandle = CK_INVALID_HANDLE;
+    pxSession->xCMACKeyHandle = CK_INVALID_HANDLE;
     mbedtls_cipher_free( &pxSession->xCMACSecretContext );
 }
 
@@ -3958,7 +3957,7 @@ static CK_RV prvInitAESCMAC( P11Session_t * pxSession,
 
     if( xResult == CKR_OK )
     {
-        pxSession->xHMACKeyHandle = hKey;
+        pxSession->xCMACKeyHandle = hKey;
     }
 
     return xResult;
@@ -4191,7 +4190,7 @@ CK_DECLARE_FUNCTION( CK_RV, C_SignInit )( CK_SESSION_HANDLE hSession,
 
                 case CKM_AES_CMAC:
 
-                    if( ( pxSession->xHMACKeyHandle == CK_INVALID_HANDLE ) || ( pxSession->xHMACKeyHandle != hKey ) )
+                    if( ( pxSession->xCMACKeyHandle == CK_INVALID_HANDLE ) || ( pxSession->xCMACKeyHandle != hKey ) )
                     {
                         xResult = prvSignInitAESCMAC( pxSession, hKey, pucKeyData, ulKeyDataLength );
                     }
@@ -4363,7 +4362,7 @@ CK_DECLARE_FUNCTION( CK_RV, C_Sign )( CK_SESSION_HANDLE hSession,
                             lMbedTLSResult = mbedtls_cipher_cmac_finish( &pxSessionObj->xCMACSecretContext, pxSignatureBuffer );
                         }
                         
-                        pxSessionObj->xHMACKeyHandle = CK_INVALID_HANDLE;
+                        pxSessionObj->xCMACKeyHandle = CK_INVALID_HANDLE;
 
                     }
                     else
@@ -4712,7 +4711,7 @@ CK_DECLARE_FUNCTION( CK_RV, C_VerifyInit )( CK_SESSION_HANDLE hSession,
 
                 case CKM_AES_CMAC:
 
-                    if( ( pxSession->xHMACKeyHandle == CK_INVALID_HANDLE ) || ( pxSession->xCMACKeyHandle != hKey ) )
+                    if( ( pxSession->xCMACKeyHandle == CK_INVALID_HANDLE ) || ( pxSession->xCMACKeyHandle != hKey ) )
                     {
                         xResult = prvVerifyInitAESCMAC( pxSession, hKey, pucKeyData, ulKeyDataLength );
                     }

--- a/source/portable/posix/core_pkcs11_pal.c
+++ b/source/portable/posix/core_pkcs11_pal.c
@@ -51,6 +51,8 @@
 #define pkcs11palFILE_NAME_PUBLIC_KEY            "FreeRTOS_P11_PubKey.dat"            /**< The file name of the Public Key object. */
 #define pkcs11palFILE_CODE_SIGN_PUBLIC_KEY       "FreeRTOS_P11_CodeSignKey.dat"       /**< The file name of the Code Sign Key object. */
 #define pkcs11palFILE_HMAC_SECRET_KEY            "FreeRTOS_P11_HMACKey.dat"           /**< The file name of the HMAC Secret Key object. */
+#define pkcs11palFILE_CMAC_SECRET_KEY            "FreeRTOS_P11_CMACKey.dat"           /**< The file name of the CMAC Secret Key object. */
+
 
 /**
  * @ingroup pkcs11_enums
@@ -64,7 +66,8 @@ enum eObjectHandles
     eAwsDevicePublicKey,      /**< Public Key. */
     eAwsDeviceCertificate,    /**< Certificate. */
     eAwsCodeSigningKey,       /**< Code Signing Key. */
-    eAwsHMACSecretKey         /**< HMAC Secret Key. */
+    eAwsHMACSecretKey,        /**< HMAC Secret Key. */
+    eAwsCMACSecretKey         /**< HMAC Secret Key. */
 };
 
 /*-----------------------------------------------------------*/
@@ -147,6 +150,13 @@ static void prvLabelToFilenameHandle( const char * pcLabel,
             *pcFileName = pkcs11palFILE_HMAC_SECRET_KEY;
             *pHandle = ( CK_OBJECT_HANDLE ) eAwsHMACSecretKey;
         }
+        else if( 0 == strncmp( pkcs11configLABEL_CMAC_KEY,
+                               pcLabel,
+                               sizeof( pkcs11configLABEL_CMAC_KEY ) ) )
+        {
+            *pcFileName = pkcs11palFILE_CMAC_SECRET_KEY;
+            *pHandle = ( CK_OBJECT_HANDLE ) eAwsCMACSecretKey;
+        }
         else
         {
             *pcFileName = NULL;
@@ -205,6 +215,12 @@ static CK_RV prvHandleToFilename( CK_OBJECT_HANDLE xHandle,
 
             case eAwsHMACSecretKey:
                 *pcFileName = pkcs11palFILE_HMAC_SECRET_KEY;
+                /* coverity[misra_c_2012_rule_10_5_violation] */
+                *pIsPrivate = ( CK_BBOOL ) CK_TRUE;
+                break;
+            
+            case eAwsCMACSecretKey:
+                *pcFileName = pkcs11palFILE_CMAC_SECRET_KEY;
                 /* coverity[misra_c_2012_rule_10_5_violation] */
                 *pIsPrivate = ( CK_BBOOL ) CK_TRUE;
                 break;

--- a/source/portable/posix/core_pkcs11_pal.c
+++ b/source/portable/posix/core_pkcs11_pal.c
@@ -218,7 +218,7 @@ static CK_RV prvHandleToFilename( CK_OBJECT_HANDLE xHandle,
                 /* coverity[misra_c_2012_rule_10_5_violation] */
                 *pIsPrivate = ( CK_BBOOL ) CK_TRUE;
                 break;
-            
+
             case eAwsCMACSecretKey:
                 *pcFileName = pkcs11palFILE_CMAC_SECRET_KEY;
                 /* coverity[misra_c_2012_rule_10_5_violation] */

--- a/test/system-test/system-tests/pkcs11_system_test.c
+++ b/test/system-test/system-tests/pkcs11_system_test.c
@@ -2205,4 +2205,8 @@ void test_AES_CMAC( void )
                                            knownSignature,
                                            sizeof( knownSignature ) );
     TEST_ASSERT_EQUAL_MESSAGE( CKR_OK, result, "AES CMAC failed to verify the known signature." );
+
+    /* Test SignInit and Sign */
+    result = globalFunctionList->C_SignInit( globalSession, &mechanism, cMacKey );
+    TEST_ASSERT_EQUAL_MESSAGE( CKR_OK, result, "Failed to C_SignInit AES CMAC." );
 }

--- a/test/system-test/system-tests/pkcs11_system_test.c
+++ b/test/system-test/system-tests/pkcs11_system_test.c
@@ -2209,4 +2209,14 @@ void test_AES_CMAC( void )
     /* Test SignInit and Sign */
     result = globalFunctionList->C_SignInit( globalSession, &mechanism, cMacKey );
     TEST_ASSERT_EQUAL_MESSAGE( CKR_OK, result, "Failed to C_SignInit AES CMAC." );
+
+        result = globalFunctionList->C_Sign( globalSession,
+                                             message,
+                                            sizeof( message ) - 1,
+                                            signature,
+                                            &signatureLength );
+    TEST_ASSERT_EQUAL_MESSAGE( CKR_OK, result, "SHA256 HMAC failed." );
+    TEST_ASSERT_EQUAL_MESSAGE( pkcs11AES_CMAC_SIGNATURE_LENGTH, signatureLength, "AES CMAC returned an unexpected size." );
+    TEST_ASSERT_EQUAL_MESSAGE( sizeof( knownSignature ), signatureLength, "AES CMAC returned a size different to the know signature." );
+    TEST_ASSERT_EQUAL_INT8_ARRAY_MESSAGE( knownSignature, signature, sizeof( knownSignature ), "The PKCS #11 generated signature was different to the known signature." );
 }

--- a/test/system-test/system-tests/pkcs11_system_test.c
+++ b/test/system-test/system-tests/pkcs11_system_test.c
@@ -2144,10 +2144,13 @@ void test_AES_CMAC( void )
     CK_OBJECT_HANDLE cMacKey;
 
     /* Min Key Size is 16 Bytes */
-    CK_BYTE keyValue[] = { 0x11, 0x22, 0x33, 0x44,
-                           0x11, 0x22, 0x33, 0x44,
-                           0x11, 0x22, 0x33, 0x44,
-                           0x11, 0x22, 0x33, 0x44 };
+    CK_BYTE keyValue[] =
+    {
+        0x11, 0x22, 0x33, 0x44,
+        0x11, 0x22, 0x33, 0x44,
+        0x11, 0x22, 0x33, 0x44,
+        0x11, 0x22, 0x33, 0x44
+    };
     CK_BYTE message[] = "Hello world";
     CK_BYTE signature[ pkcs11AES_CMAC_SIGNATURE_LENGTH ] = { 0 };
     size_t signatureLength = sizeof( signature );
@@ -2162,7 +2165,7 @@ void test_AES_CMAC( void )
     CK_BYTE knownSignature[] =
     {
         0x36, 0xcd, 0xa8, 0x42,
-        0x6c, 0xbb, 0xec, 0xae, 
+        0x6c, 0xbb, 0xec, 0xae,
         0x10, 0x78, 0x3e, 0xb7,
         0x2e, 0x52, 0x62, 0xb7
     };
@@ -2178,7 +2181,7 @@ void test_AES_CMAC( void )
         { CKA_TOKEN,    &trueObject,   sizeof( CK_BBOOL )        },
         { CKA_SIGN,     &trueObject,   sizeof( CK_BBOOL )        },
         { CKA_VERIFY,   &trueObject,   sizeof( CK_BBOOL )        },
-        { CKA_VALUE,    keyValue,      sizeof( keyValue )    }
+        { CKA_VALUE,    keyValue,      sizeof( keyValue )        }
     };
 
 

--- a/test/system-test/system-tests/pkcs11_system_test.c
+++ b/test/system-test/system-tests/pkcs11_system_test.c
@@ -2130,3 +2130,76 @@ void test_SHA256_HMAC( void )
     TEST_ASSERT_EQUAL_INT8_ARRAY_MESSAGE( knownSignature, signature, sizeof( knownSignature ), "The PKCS #11 generated signature was different to the known signature." );
 }
 /*-----------------------------------------------------------*/
+
+void test_AES_CMAC( void )
+{
+    CK_RV result;
+    CK_FUNCTION_LIST_PTR functionList;
+
+    CK_BYTE label[] = pkcs11testLABEL_CMAC_KEY;
+    CK_KEY_TYPE cmacKeyType = CKK_AES;
+    CK_OBJECT_CLASS cmacKeyClass = CKO_SECRET_KEY;
+    CK_BBOOL trueObject = CK_TRUE;
+
+    CK_OBJECT_HANDLE cMacKey;
+
+    /* Min Key Size is 16 Bytes */
+    CK_BYTE keyValue[] = { 0x11, 0x22, 0x33, 0x44,
+                           0x11, 0x22, 0x33, 0x44,
+                           0x11, 0x22, 0x33, 0x44,
+                           0x11, 0x22, 0x33, 0x44 };
+    CK_BYTE message[] = "Hello world";
+    CK_BYTE signature[ pkcs11AES_CMAC_SIGNATURE_LENGTH ] = { 0 };
+    size_t signatureLength = sizeof( signature );
+
+    CK_MECHANISM mechanism =
+    {
+        CKM_AES_CMAC, NULL_PTR, 0
+    };
+
+    /* Generated with: */
+    /* $ echo -n "Hello world" | openssl dgst -mac cmac -macopt cipher:aes-128-cbc -macopt hexkey:11223344112233441122334411223344 */
+    CK_BYTE knownSignature[] =
+    {
+        0x36, 0xcd, 0xa8, 0x42,
+        0x6c, 0xbb, 0xec, 0xae, 
+        0x10, 0x78, 0x3e, 0xb7,
+        0x2e, 0x52, 0x62, 0xb7
+    };
+
+    result = C_GetFunctionList( &functionList );
+    TEST_ASSERT_EQUAL_MESSAGE( CKR_OK, result, "Failed to get PKCS #11 function list." );
+
+    CK_ATTRIBUTE aes_cmac_template[] =
+    {
+        { CKA_CLASS,    &cmacKeyClass, sizeof( CK_OBJECT_CLASS ) },
+        { CKA_KEY_TYPE, &cmacKeyType,  sizeof( CK_KEY_TYPE )     },
+        { CKA_LABEL,    label,         sizeof( label ) - 1       },
+        { CKA_TOKEN,    &trueObject,   sizeof( CK_BBOOL )        },
+        { CKA_SIGN,     &trueObject,   sizeof( CK_BBOOL )        },
+        { CKA_VERIFY,   &trueObject,   sizeof( CK_BBOOL )        },
+        { CKA_VALUE,    keyValue,      sizeof( keyValue ) - 1    }
+    };
+
+
+    /* Create the template objects */
+    result = functionList->C_CreateObject( globalSession,
+                                           ( CK_ATTRIBUTE_PTR ) &aes_cmac_template,
+                                           sizeof( aes_cmac_template ) / sizeof( CK_ATTRIBUTE ),
+                                           &cMacKey );
+    TEST_ASSERT_EQUAL_MESSAGE( CKR_OK, result, "Failed to create AES CMAC object." );
+    TEST_ASSERT_NOT_EQUAL_MESSAGE( CK_INVALID_HANDLE, cMacKey, "AES CMAC key is invalid." );
+
+
+    result = globalFunctionList->C_VerifyInit( globalSession, &mechanism, cMacKey );
+    TEST_ASSERT_EQUAL_MESSAGE( CKR_OK, result, "Failed to C_VerifyInit SHA256 HMAC." );
+
+
+    /* Verify the precomputed signature */
+    result = globalFunctionList->C_Verify( globalSession,
+                                           message,
+                                           sizeof( message ) - 1,
+                                           knownSignature,
+                                           sizeof( knownSignature ) );
+    TEST_ASSERT_EQUAL_MESSAGE( CKR_OK, result, "AES CMAC failed to verify the known signature." );
+}

--- a/test/system-test/system-tests/pkcs11_system_test.c
+++ b/test/system-test/system-tests/pkcs11_system_test.c
@@ -2161,7 +2161,7 @@ void test_AES_CMAC( void )
     };
 
     /* Generated with: */
-    /* $ echo -n "Hello world" | openssl dgst -mac cmac -macopt cipher:aes-128-cbc -macopt hexkey:11223344112233441122334411223344 */
+    /* $ echo -n "Hello world" | openssl dgst -mac cmac -macopt cipher:aes-128-ecb -macopt hexkey:11223344112233441122334411223344 */
     CK_BYTE knownSignature[] =
     {
         0x36, 0xcd, 0xa8, 0x42,

--- a/test/system-test/system-tests/pkcs11_system_test.c
+++ b/test/system-test/system-tests/pkcs11_system_test.c
@@ -2178,7 +2178,7 @@ void test_AES_CMAC( void )
         { CKA_TOKEN,    &trueObject,   sizeof( CK_BBOOL )        },
         { CKA_SIGN,     &trueObject,   sizeof( CK_BBOOL )        },
         { CKA_VERIFY,   &trueObject,   sizeof( CK_BBOOL )        },
-        { CKA_VALUE,    keyValue,      sizeof( keyValue ) - 1    }
+        { CKA_VALUE,    keyValue,      sizeof( keyValue )    }
     };
 
 

--- a/test/system-test/test-config/core_pkcs11_config.h
+++ b/test/system-test/test-config/core_pkcs11_config.h
@@ -159,6 +159,11 @@
 #define pkcs11configLABEL_HMAC_KEY                         "HMAC Key"
 
 /**
+ * @brief The PKCS #11 label for the object to be used for CMAC operations.
+ */
+#define pkcs11configLABEL_CMAC_KEY                         "CMAC Key"
+
+/**
  * @brief The PKCS #11 label for the object to be used for code verification.
  *
  * Used by over-the-air update code to verify an incoming signed image.

--- a/test/system-test/test-config/core_test_pkcs11_config.h
+++ b/test/system-test/test-config/core_test_pkcs11_config.h
@@ -120,6 +120,15 @@
 #define pkcs11testLABEL_HMAC_KEY                      pkcs11configLABEL_HMAC_KEY
 
 /**
+ * @brief The PKCS #11 label for the object to be used for CMAC operations.
+ *
+ * For devices with on-chip storage, this should match the non-test label.
+ * For devices with secure elements or hardware limitations, this may be defined
+ * to a different label to preserve AWS IoT credentials for other test suites.
+ */
+#define pkcs11testLABEL_CMAC_KEY                      pkcs11configLABEL_CMAC_KEY
+
+/**
  * @brief The PKCS #11 label for the AWS Trusted Root Certificate.
  *
  * @see aws_default_root_certificates.h

--- a/test/system-test/test-config/mbedtls_config.h
+++ b/test/system-test/test-config/mbedtls_config.h
@@ -2179,7 +2179,7 @@
  * Requires: MBEDTLS_AES_C or MBEDTLS_DES_C
  *
  */
-/*#define MBEDTLS_CMAC_C */
+#define MBEDTLS_CMAC_C
 
 /**
  * \def MBEDTLS_CTR_DRBG_C

--- a/test/unit-test/CMakeLists.txt
+++ b/test/unit-test/CMakeLists.txt
@@ -155,6 +155,8 @@ list(APPEND mock_list
             "${MODULE_ROOT_DIR}/source/dependency/3rdparty/mbedtls/include/mbedtls/pk.h"
             "${MODULE_ROOT_DIR}/source/dependency/3rdparty/mbedtls/include/mbedtls/x509_crt.h"
             "${MODULE_ROOT_DIR}/source/dependency/3rdparty/mbedtls/include/mbedtls/md.h"
+            "${MODULE_ROOT_DIR}/source/dependency/3rdparty/mbedtls/include/mbedtls/cmac.h"
+            "${MODULE_ROOT_DIR}/source/dependency/3rdparty/mbedtls/include/mbedtls/cipher.h"
             "${MODULE_ROOT_DIR}/source/include/core_pki_utils.h"
     )
 

--- a/test/unit-test/config/aws_mbedtls_config.h
+++ b/test/unit-test/config/aws_mbedtls_config.h
@@ -1962,7 +1962,7 @@
  * Requires: MBEDTLS_AES_C or MBEDTLS_DES_C
  *
  */
-/*#define MBEDTLS_CMAC_C */
+#define MBEDTLS_CMAC_C
 
 /**
  * \def MBEDTLS_CTR_DRBG_C


### PR DESCRIPTION
Add `C_VerifyInit`, `C_Verify`, `C_SignInit`, and `C_Sign`, as required by NTP client.