### PR TITLE
Fix doxygen main page generation

### DIFF
--- a/docs/doxygen/pages.dox
+++ b/docs/doxygen/pages.dox
@@ -1,5 +1,5 @@
 /**
-@mainpage
+@mainpage Overview
 @anchor core_pkcs11
 @brief PKCS #11 Crypto Abstraction Library.
 
@@ -12,9 +12,7 @@ This PKCS #11 library implements a subset of the PKCS #11 API required to establ
 - Signing a message.
 - Managing certificates and keys.
 - Generating random numbers.
-*/
 
-/**
 @section pkcs11_memory_requirements Memory Requirements
 @brief Memory requirements of the PKCS #11 library.
 


### PR DESCRIPTION
Fix bug in pages.dox causing memory table section to appear on wrong page.
This makes the documentation's main page consistent with the other libraries.