### PR TITLE
Fix backwards compatibility support for deprecated configs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Change Log for corePKCS11 Library
 
 ## v3.2.0 (August 2021)
+- [#123](https://github.com/FreeRTOS/corePKCS11/pull/121) Add backwards compatibility for deprecated configuration macros.
 - [#121](https://github.com/FreeRTOS/corePKCS11/pull/121) Add labels for supporting Claim credentials useful for Fleet Provisioning feature of AWS IoT Core.
 - [#122](https://github.com/FreeRTOS/corePKCS11/pull/122) Add `core_pkcs11_config_defaults.h` file for default definition of configuration macros. and make doxygen documentation fixes.
 

--- a/lexicon.txt
+++ b/lexicon.txt
@@ -63,6 +63,7 @@ digestinfo
 digestinit
 digestkey
 digestupdate
+doxygen
 drbg
 eawsclaimcertificate
 eawsclaimprivatekey

--- a/source/include/core_pkcs11_config_defaults.h
+++ b/source/include/core_pkcs11_config_defaults.h
@@ -39,6 +39,25 @@
 /* *INDENT-ON* */
 
 /**
+ * @brief Definitions mapping deprecated configuration macro names to their current equivalent
+ * configurations for backwards compatibility of API.
+ */
+#ifndef DOXYGEN
+    #ifdef PKCS11_MALLOC
+        #define pkcs11configPKCS11_MALLOC    PKCS11_MALLOC
+    #endif
+
+    #ifdef PKCS11_FREE
+        #define pkcs11configPKCS11_FREE    PKCS11_FREE
+    #endif
+
+    #ifdef configPKCS11_DEFAULT_USER_PIN
+        #define pkcs11configPKCS11_DEFAULT_USER_PIN    configPKCS11_DEFAULT_USER_PIN
+    #endif
+#endif /* ifndef DOXYGEN */
+
+
+/**
  * @brief Malloc API used by iot_pkcs11.h
  *
  * <br><b>Possible values:</b> Any platform-specific function for allocating memory.<br>
@@ -327,16 +346,6 @@
  */
 #ifndef LogDebug
     #define LogDebug( message )
-#endif
-
-/**
- * @brief Definitions mapping deprecated configuration macro names to their current equivalent
- * configurations for backwards compatibility of API.
- */
-#ifndef DOXYGEN
-    #define PKCS11_MALLOC                    pkcs11configPKCS11_MALLOC
-    #define PKCS11_FREE                      pkcs11configPKCS11_FREE
-    #define configPKCS11_DEFAULT_USER_PIN    pkcs11configPKCS11_DEFAULT_USER_PIN
 #endif
 
 /* *INDENT-OFF* */


### PR DESCRIPTION
This PR fixes the logic of providing backwards comptability support for `PKCS11_MALLOC`, `PKCS11_FREE` and `configPKCS11_DEFAULT_USER_PIN` configuration macros.