### PR TITLE
Fix memory leaks in corePKCS11

### DIFF
--- a/docs/doxygen/include/size_table.md
+++ b/docs/doxygen/include/size_table.md
@@ -19,12 +19,12 @@
     </tr>
     <tr>
         <td>core_pkcs11_mbedtls.c</td>
-        <td><center>8.6K</center></td>
-        <td><center>7.1K</center></td>
+        <td><center>8.7K</center></td>
+        <td><center>7.2K</center></td>
     </tr>
     <tr>
         <td><b>Total estimates</b></td>
-        <td><b><center>9.9K</center></b></td>
-        <td><b><center>8.2K</center></b></td>
+        <td><b><center>10.0K</center></b></td>
+        <td><b><center>8.3K</center></b></td>
     </tr>
 </table>

--- a/source/portable/mbedtls/core_pkcs11_mbedtls.c
+++ b/source/portable/mbedtls/core_pkcs11_mbedtls.c
@@ -4217,6 +4217,11 @@ CK_DECLARE_FUNCTION( CK_RV, C_SignInit )( CK_SESSION_HANDLE hSession,
         }
     }
 
+    if( xPalHandle != CK_INVALID_HANDLE )
+    {
+        PKCS11_PAL_GetObjectValueCleanup( pucKeyData, ulKeyDataLength );
+    }
+
     if( xResult == CKR_OK )
     {
         LogDebug( ( "Sign mechanism set to 0x%0lX.", ( unsigned long int ) pMechanism->mechanism ) );
@@ -4350,7 +4355,7 @@ CK_DECLARE_FUNCTION( CK_RV, C_Sign )( CK_SESSION_HANDLE hSession,
                             lMbedTLSResult = mbedtls_md_hmac_finish( &pxSessionObj->xHMACSecretContext, pxSignatureBuffer );
                         }
 
-                        pxSessionObj->xHMACKeyHandle = CK_INVALID_HANDLE;
+                        prvHMACCleanUp( pxSessionObj );
                     }
                     else if( pxSessionObj->xOperationSignMechanism == CKM_AES_CMAC )
                     {
@@ -4361,7 +4366,7 @@ CK_DECLARE_FUNCTION( CK_RV, C_Sign )( CK_SESSION_HANDLE hSession,
                             lMbedTLSResult = mbedtls_cipher_cmac_finish( &pxSessionObj->xCMACSecretContext, pxSignatureBuffer );
                         }
 
-                        pxSessionObj->xCMACKeyHandle = CK_INVALID_HANDLE;
+                        prvCMACCleanUp( pxSessionObj );
                     }
                     else
                     {
@@ -4391,6 +4396,7 @@ CK_DECLARE_FUNCTION( CK_RV, C_Sign )( CK_SESSION_HANDLE hSession,
                                                               mbedtls_ctr_drbg_random,
                                                               &xP11Context.xMbedDrbgCtx );
                         }
+                        prvSignInitEC_RSACleanUp( pxSessionObj );
                     }
 
                     if( ( xResult == CKR_OK ) && ( lMbedTLSResult != 0 ) )

--- a/source/portable/mbedtls/core_pkcs11_mbedtls.c
+++ b/source/portable/mbedtls/core_pkcs11_mbedtls.c
@@ -4396,6 +4396,7 @@ CK_DECLARE_FUNCTION( CK_RV, C_Sign )( CK_SESSION_HANDLE hSession,
                                                               mbedtls_ctr_drbg_random,
                                                               &xP11Context.xMbedDrbgCtx );
                         }
+
                         prvSignInitEC_RSACleanUp( pxSessionObj );
                     }
 

--- a/test/unit-test/core_pkcs11_mbedtls_utest.c
+++ b/test/unit-test/core_pkcs11_mbedtls_utest.c
@@ -4391,6 +4391,7 @@ void test_pkcs11_C_SignSHA256HMAC( void )
 
         mbedtls_md_hmac_update_ExpectAnyArgsAndReturn( 0 );
         mbedtls_md_hmac_finish_ExpectAnyArgsAndReturn( 0 );
+        mbedtls_md_free_CMockIgnore();
         xResult = C_Sign( xSession, pxDummyData, ulDummyDataLen, pxDummySignature, &ulDummySignatureLen );
         TEST_ASSERT_EQUAL( CKR_OK, xResult );
     }
@@ -4438,6 +4439,7 @@ void test_pkcs11_C_SignSHA256HMACUpdateFail( void )
         TEST_ASSERT_EQUAL( CKR_OK, xResult );
 
         mbedtls_md_hmac_update_ExpectAnyArgsAndReturn( -1 );
+        mbedtls_md_free_CMockIgnore();
         xResult = C_Sign( xSession, pxDummyData, ulDummyDataLen, pxDummySignature, &ulDummySignatureLen );
         TEST_ASSERT_EQUAL( CKR_FUNCTION_FAILED, xResult );
     }
@@ -4486,6 +4488,7 @@ void test_pkcs11_C_SignAESCMAC( void )
 
         mbedtls_cipher_cmac_update_ExpectAnyArgsAndReturn( 0 );
         mbedtls_cipher_cmac_finish_ExpectAnyArgsAndReturn( 0 );
+        mbedtls_cipher_free_CMockIgnore();
         xResult = C_Sign( xSession, pxDummyData, ulDummyDataLen, pxDummySignature, &ulDummySignatureLen );
         TEST_ASSERT_EQUAL( CKR_OK, xResult );
     }
@@ -4533,6 +4536,7 @@ void test_pkcs11_C_SignAESCMACUpdateFail( void )
         TEST_ASSERT_EQUAL( CKR_OK, xResult );
 
         mbedtls_cipher_cmac_update_ExpectAnyArgsAndReturn( -1 );
+        mbedtls_cipher_free_CMockIgnore();
         xResult = C_Sign( xSession, pxDummyData, ulDummyDataLen, pxDummySignature, &ulDummySignatureLen );
         TEST_ASSERT_EQUAL( CKR_FUNCTION_FAILED, xResult );
     }


### PR DESCRIPTION
This commit fixes 2 memory leaks:

1. `C_SignInit` allocates memory which should be released in `C_Sign`.
2. `C_SignInit` needs to call `PKCS11_PAL_GetObjectValueCleanup` to free the  memory allocated in `PKCS11_PAL_GetObjectValue`.

