### PR TITLE
Fix invalid memory read in system tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,10 @@
 # Change Log for corePKCS11 Library
+- [#128](https://github.com/FreeRTOS/corePKCS11/pull/128) Fix invalid memory read in system tests.
+- [#126](https://github.com/FreeRTOS/corePKCS11/pull/126) Add default values for configuration macros.
+- [#125](https://github.com/FreeRTOS/corePKCS11/pull/125) Fix memory leaks in corePKCS11.
 
 ## v3.2.0 (August 2021)
-- [#123](https://github.com/FreeRTOS/corePKCS11/pull/121) Add backwards compatibility for deprecated configuration macros.
+- [#123](https://github.com/FreeRTOS/corePKCS11/pull/123) Add backwards compatibility for deprecated configuration macros.
 - [#121](https://github.com/FreeRTOS/corePKCS11/pull/121) Add labels for supporting Claim credentials useful for Fleet Provisioning feature of AWS IoT Core.
 - [#122](https://github.com/FreeRTOS/corePKCS11/pull/122) Add `core_pkcs11_config_defaults.h` file for default definition of configuration macros. and make doxygen documentation fixes.
 

--- a/docs/doxygen/include/size_table.md
+++ b/docs/doxygen/include/size_table.md
@@ -20,11 +20,11 @@
     <tr>
         <td>core_pkcs11_mbedtls.c</td>
         <td><center>8.7K</center></td>
-        <td><center>7.2K</center></td>
+        <td><center>7.3K</center></td>
     </tr>
     <tr>
         <td><b>Total estimates</b></td>
         <td><b><center>10.0K</center></b></td>
-        <td><b><center>8.3K</center></b></td>
+        <td><b><center>8.4K</center></b></td>
     </tr>
 </table>

--- a/source/portable/mbedtls/core_pkcs11_mbedtls.c
+++ b/source/portable/mbedtls/core_pkcs11_mbedtls.c
@@ -4895,6 +4895,8 @@ CK_DECLARE_FUNCTION( CK_RV, C_Verify )( CK_SESSION_HANDLE hSession,
 
                     xResult = CKR_SIGNATURE_INVALID;
                 }
+
+                prvVerifyInitEC_RSACleanUp( pxSessionObj );
             }
             /* Perform an ECDSA verification. */
             else if( pxSessionObj->xOperationVerifyMechanism == CKM_ECDSA )
@@ -4951,6 +4953,7 @@ CK_DECLARE_FUNCTION( CK_RV, C_Verify )( CK_SESSION_HANDLE hSession,
 
                 mbedtls_mpi_free( &xR );
                 mbedtls_mpi_free( &xS );
+                prvVerifyInitEC_RSACleanUp( pxSessionObj );
             }
             else if( pxSessionObj->xOperationVerifyMechanism == CKM_SHA256_HMAC )
             {
@@ -4967,7 +4970,6 @@ CK_DECLARE_FUNCTION( CK_RV, C_Verify )( CK_SESSION_HANDLE hSession,
                 else
                 {
                     lMbedTLSResult = mbedtls_md_hmac_finish( &pxSessionObj->xHMACSecretContext, pxHMACBuffer );
-                    pxSessionObj->xHMACKeyHandle = CK_INVALID_HANDLE;
 
                     if( lMbedTLSResult != 0 )
                     {
@@ -4986,6 +4988,7 @@ CK_DECLARE_FUNCTION( CK_RV, C_Verify )( CK_SESSION_HANDLE hSession,
                         }
                     }
                 }
+                prvHMACCleanUp( pxSessionObj );
             }
             else if( pxSessionObj->xOperationVerifyMechanism == CKM_AES_CMAC )
             {
@@ -5021,7 +5024,7 @@ CK_DECLARE_FUNCTION( CK_RV, C_Verify )( CK_SESSION_HANDLE hSession,
                     }
                 }
 
-                pxSessionObj->xCMACKeyHandle = CK_INVALID_HANDLE;
+                prvCMACCleanUp( pxSessionObj );
             }
             else
             {

--- a/source/portable/mbedtls/core_pkcs11_mbedtls.c
+++ b/source/portable/mbedtls/core_pkcs11_mbedtls.c
@@ -4988,6 +4988,7 @@ CK_DECLARE_FUNCTION( CK_RV, C_Verify )( CK_SESSION_HANDLE hSession,
                         }
                     }
                 }
+
                 prvHMACCleanUp( pxSessionObj );
             }
             else if( pxSessionObj->xOperationVerifyMechanism == CKM_AES_CMAC )

--- a/test/system-test/system-tests/pkcs11_system_test.c
+++ b/test/system-test/system-tests/pkcs11_system_test.c
@@ -1935,13 +1935,13 @@ static CK_RV provisionPublicKey( CK_SESSION_HANDLE session,
                                              NULL, 0 );
         CK_ATTRIBUTE publicKeyTemplate[] =
         {
-            { CKA_CLASS,           NULL /* &class */,         sizeof( CK_OBJECT_CLASS )                 },
-            { CKA_KEY_TYPE,        NULL /* &publicKeyType */, sizeof( CK_KEY_TYPE )                     },
-            { CKA_TOKEN,           NULL /* &trueObject */,    sizeof( trueObject )                      },
-            { CKA_MODULUS,         NULL /* &modulus[ 1 ] */,  MODULUS_LENGTH                            },          /* Extra byte allocated at beginning for 0 padding. */
-            { CKA_VERIFY,          NULL /* &trueObject */,    sizeof( trueObject )                      },
-            { CKA_PUBLIC_EXPONENT, NULL /* publicExponent */, sizeof( publicExponent )                  },
-            { CKA_LABEL,           publicKeyLabel,            strlen( ( const char * ) publicKeyLabel ) }
+            { CKA_CLASS,           NULL /* &class */,           sizeof( CK_OBJECT_CLASS )                 },
+            { CKA_KEY_TYPE,        NULL /* &publicKeyType */,   sizeof( CK_KEY_TYPE )                     },
+            { CKA_TOKEN,           NULL /* &trueObject */,      sizeof( trueObject )                      },
+            { CKA_MODULUS,         NULL /* &( modulus[ 1 ] ) */,MODULUS_LENGTH                            },          /* Extra byte allocated at beginning for 0 padding. */
+            { CKA_VERIFY,          NULL /* &trueObject */,      sizeof( trueObject )                      },
+            { CKA_PUBLIC_EXPONENT, NULL /* publicExponent */,   sizeof( publicExponent )                  },
+            { CKA_LABEL,           publicKeyLabel,              strlen( ( const char * ) publicKeyLabel ) }
         };
 
         /* Aggregate initializers must not use the address of an automatic variable. */
@@ -1949,7 +1949,7 @@ static CK_RV provisionPublicKey( CK_SESSION_HANDLE session,
         publicKeyTemplate[ 0 ].pValue = &class;
         publicKeyTemplate[ 1 ].pValue = &publicKeyType;
         publicKeyTemplate[ 2 ].pValue = &trueObject;
-        publicKeyTemplate[ 3 ].pValue = &modulus[ 1 ];
+        publicKeyTemplate[ 3 ].pValue = &( modulus[ 1 ] );
         publicKeyTemplate[ 4 ].pValue = &trueObject;
         publicKeyTemplate[ 5 ].pValue = publicExponent;
 

--- a/test/system-test/system-tests/pkcs11_system_test.c
+++ b/test/system-test/system-tests/pkcs11_system_test.c
@@ -1935,13 +1935,13 @@ static CK_RV provisionPublicKey( CK_SESSION_HANDLE session,
                                              NULL, 0 );
         CK_ATTRIBUTE publicKeyTemplate[] =
         {
-            { CKA_CLASS,           NULL /* &class */,           sizeof( CK_OBJECT_CLASS )                 },
-            { CKA_KEY_TYPE,        NULL /* &publicKeyType */,   sizeof( CK_KEY_TYPE )                     },
-            { CKA_TOKEN,           NULL /* &trueObject */,      sizeof( trueObject )                      },
-            { CKA_MODULUS,         NULL /* &( modulus[ 1 ] ) */,MODULUS_LENGTH                            },          /* Extra byte allocated at beginning for 0 padding. */
-            { CKA_VERIFY,          NULL /* &trueObject */,      sizeof( trueObject )                      },
-            { CKA_PUBLIC_EXPONENT, NULL /* publicExponent */,   sizeof( publicExponent )                  },
-            { CKA_LABEL,           publicKeyLabel,              strlen( ( const char * ) publicKeyLabel ) }
+            { CKA_CLASS,           NULL /* &class */,            sizeof( CK_OBJECT_CLASS )                 },
+            { CKA_KEY_TYPE,        NULL /* &publicKeyType */,    sizeof( CK_KEY_TYPE )                     },
+            { CKA_TOKEN,           NULL /* &trueObject */,       sizeof( trueObject )                      },
+            { CKA_MODULUS,         NULL /* &( modulus[ 1 ] ) */, MODULUS_LENGTH                            },         /* Extra byte allocated at beginning for 0 padding. */
+            { CKA_VERIFY,          NULL /* &trueObject */,       sizeof( trueObject )                      },
+            { CKA_PUBLIC_EXPONENT, NULL /* publicExponent */,    sizeof( publicExponent )                  },
+            { CKA_LABEL,           publicKeyLabel,               strlen( ( const char * ) publicKeyLabel ) }
         };
 
         /* Aggregate initializers must not use the address of an automatic variable. */

--- a/test/system-test/system-tests/pkcs11_system_test.c
+++ b/test/system-test/system-tests/pkcs11_system_test.c
@@ -1938,7 +1938,7 @@ static CK_RV provisionPublicKey( CK_SESSION_HANDLE session,
             { CKA_CLASS,           NULL /* &class */,         sizeof( CK_OBJECT_CLASS )                 },
             { CKA_KEY_TYPE,        NULL /* &publicKeyType */, sizeof( CK_KEY_TYPE )                     },
             { CKA_TOKEN,           NULL /* &trueObject */,    sizeof( trueObject )                      },
-            { CKA_MODULUS,         NULL /* &modulus + 1 */,   MODULUS_LENGTH                            },          /* Extra byte allocated at beginning for 0 padding. */
+            { CKA_MODULUS,         NULL /* &modulus[ 1 ] */,  MODULUS_LENGTH                            },          /* Extra byte allocated at beginning for 0 padding. */
             { CKA_VERIFY,          NULL /* &trueObject */,    sizeof( trueObject )                      },
             { CKA_PUBLIC_EXPONENT, NULL /* publicExponent */, sizeof( publicExponent )                  },
             { CKA_LABEL,           publicKeyLabel,            strlen( ( const char * ) publicKeyLabel ) }
@@ -1949,7 +1949,7 @@ static CK_RV provisionPublicKey( CK_SESSION_HANDLE session,
         publicKeyTemplate[ 0 ].pValue = &class;
         publicKeyTemplate[ 1 ].pValue = &publicKeyType;
         publicKeyTemplate[ 2 ].pValue = &trueObject;
-        publicKeyTemplate[ 3 ].pValue = &modulus + 1;
+        publicKeyTemplate[ 3 ].pValue = &modulus[ 1 ];
         publicKeyTemplate[ 4 ].pValue = &trueObject;
         publicKeyTemplate[ 5 ].pValue = publicExponent;
 

--- a/test/unit-test/core_pkcs11_mbedtls_utest.c
+++ b/test/unit-test/core_pkcs11_mbedtls_utest.c
@@ -5363,6 +5363,7 @@ void test_pkcs11_C_VerifyRSA( void )
         TEST_ASSERT_EQUAL( CKR_OK, xResult );
 
         mbedtls_pk_verify_IgnoreAndReturn( 0 );
+        mbedtls_pk_free_CMockIgnore();
         xResult = C_Verify( xSession, pxDummyData, ulDummyDataLen, pxDummySignature, ulDummySignatureLen );
         TEST_ASSERT_EQUAL( CKR_OK, xResult );
     }
@@ -5445,7 +5446,6 @@ void test_pkcs11_C_VerifyBadArgs( void )
         TEST_ASSERT_EQUAL( CKR_SIGNATURE_LEN_RANGE, xResult );
 
         xMechanism.mechanism = CKM_RSA_X_509;
-        mbedtls_pk_get_type_IgnoreAndReturn( MBEDTLS_PK_RSA );
         PKCS11_PAL_GetObjectValue_ExpectAnyArgsAndReturn( CKR_OK );
         PKCS11_PAL_GetObjectValue_ReturnThruPtr_pIsPrivate( &xIsPrivate );
         xResult = C_VerifyInit( xSession, &xMechanism, xObject );
@@ -5534,6 +5534,7 @@ void test_pkcs11_C_VerifySHA256HMAC( void )
         mbedtls_md_hmac_update_ExpectAnyArgsAndReturn( 0 );
         mbedtls_md_hmac_finish_ExpectAnyArgsAndReturn( 0 );
         mbedtls_md_hmac_finish_ReturnThruPtr_output( pxDummySignature );
+        mbedtls_md_free_CMockIgnore();
         xResult = C_Verify( xSession, pxDummyData, ulDummyDataLen, pxDummySignature, ulDummySignatureLen );
         TEST_ASSERT_EQUAL( CKR_OK, xResult );
     }
@@ -5580,6 +5581,7 @@ void test_pkcs11_C_VerifySHA256HMACUpdateFail( void )
         TEST_ASSERT_EQUAL( CKR_OK, xResult );
 
         mbedtls_md_hmac_update_ExpectAnyArgsAndReturn( -1 );
+        mbedtls_md_free_CMockIgnore();
         xResult = C_Verify( xSession, pxDummyData, ulDummyDataLen, pxDummySignature, ulDummySignatureLen );
         TEST_ASSERT_EQUAL( CKR_SIGNATURE_INVALID, xResult );
     }
@@ -5627,6 +5629,7 @@ void test_pkcs11_C_VerifySHA256HMACFinishFail( void )
 
         mbedtls_md_hmac_update_ExpectAnyArgsAndReturn( 0 );
         mbedtls_md_hmac_finish_ExpectAnyArgsAndReturn( -1 );
+        mbedtls_md_free_CMockIgnore();
         xResult = C_Verify( xSession, pxDummyData, ulDummyDataLen, pxDummySignature, ulDummySignatureLen );
         TEST_ASSERT_EQUAL( CKR_SIGNATURE_INVALID, xResult );
     }
@@ -5677,6 +5680,7 @@ void test_pkcs11_C_VerifySHA256HMACInvalidSig( void )
         mbedtls_md_hmac_update_ExpectAnyArgsAndReturn( 0 );
         mbedtls_md_hmac_finish_ExpectAnyArgsAndReturn( 0 );
         mbedtls_md_hmac_finish_ReturnThruPtr_output( pxBadSignature );
+        mbedtls_md_free_CMockIgnore();
         xResult = C_Verify( xSession, pxDummyData, ulDummyDataLen, pxDummySignature, ulDummySignatureLen );
         TEST_ASSERT_EQUAL( CKR_SIGNATURE_INVALID, xResult );
     }
@@ -5725,6 +5729,7 @@ void test_pkcs11_C_VerifyAESCMAC( void )
         mbedtls_cipher_cmac_update_ExpectAnyArgsAndReturn( 0 );
         mbedtls_cipher_cmac_finish_ExpectAnyArgsAndReturn( 0 );
         mbedtls_cipher_cmac_finish_ReturnThruPtr_output( pxDummySignature );
+        mbedtls_cipher_free_CMockIgnore();
         xResult = C_Verify( xSession, pxDummyData, ulDummyDataLen, pxDummySignature, ulDummySignatureLen );
         TEST_ASSERT_EQUAL( CKR_OK, xResult );
     }
@@ -5771,6 +5776,7 @@ void test_pkcs11_C_VerifyAESCMACCipherUpdateFail( void )
         TEST_ASSERT_EQUAL( CKR_OK, xResult );
 
         mbedtls_cipher_cmac_update_ExpectAnyArgsAndReturn( -1 );
+        mbedtls_cipher_free_CMockIgnore();
         xResult = C_Verify( xSession, pxDummyData, ulDummyDataLen, pxDummySignature, ulDummySignatureLen );
         TEST_ASSERT_EQUAL( CKR_SIGNATURE_INVALID, xResult );
     }
@@ -5818,6 +5824,7 @@ void test_pkcs11_C_VerifyAESCMACFinishFail( void )
 
         mbedtls_cipher_cmac_update_ExpectAnyArgsAndReturn( 0 );
         mbedtls_cipher_cmac_finish_ExpectAnyArgsAndReturn( -1 );
+        mbedtls_cipher_free_CMockIgnore();
         xResult = C_Verify( xSession, pxDummyData, ulDummyDataLen, pxDummySignature, ulDummySignatureLen );
         TEST_ASSERT_EQUAL( CKR_SIGNATURE_INVALID, xResult );
     }
@@ -5868,6 +5875,7 @@ void test_pkcs11_C_VerifyAESCMACInvalidSig( void )
         mbedtls_cipher_cmac_update_ExpectAnyArgsAndReturn( 0 );
         mbedtls_cipher_cmac_finish_ExpectAnyArgsAndReturn( 0 );
         mbedtls_cipher_cmac_finish_ReturnThruPtr_output( pxBadSignature );
+        mbedtls_cipher_free_CMockIgnore();
         xResult = C_Verify( xSession, pxDummyData, ulDummyDataLen, pxDummySignature, ulDummySignatureLen );
         TEST_ASSERT_EQUAL( CKR_SIGNATURE_INVALID, xResult );
     }


### PR DESCRIPTION
This PR addresses the following 2 issues:

1. The test `test_CreateObject_RSA` defines a buffer (named `modulus`) of size 257 on the stack: 

```c
CK_BYTE modulus[ 257 ] = { 0 };
```
The test wants to pass the address of second byte in the buffer to the `C_CreateObject` function. The test code was incorrectly using the expression `&modulus + 1` which was resulting in address of the memory right after the buffer. This commits updates the expression to `&modulus[ 1 ]` to correctly use the address of the second byte.

2. This commit also fixes a memory leak by ensuring that the memory allocated in the `C_VerifyInit` is freed in `C_Verify`.
