### PR TITLE
Enable address sanitizer for tests in PR checks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,7 +37,7 @@ jobs:
         run: |
           sudo apt-get install -y lcov
           CFLAGS="--coverage -Wall -Wextra -DNDEBUG"
-          CFLAGS+=" -fsanitize=address,undefined"
+          #CFLAGS+=" -fsanitize=address,undefined"
           cmake -S test -B build/ \
           -G "Unix Makefiles" \
           -DCMAKE_BUILD_TYPE=Debug \

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,12 +15,14 @@ jobs:
         uses: actions/checkout@v2
       - name: Build
         run: |
+          CFLAGS="-Wall -Wextra -DNDEBUG -DLIBRARY_LOG_LEVEL=LOG_DEBUG"
+          CFLAGS+=" -fsanitize=address,undefined"
           cmake -S test -B build/ \
           -G "Unix Makefiles" \
           -DCMAKE_BUILD_TYPE=Debug \
           -DBUILD_CLONE_SUBMODULES=ON \
           -DSYSTEM_TESTS=1 \
-          -DCMAKE_C_FLAGS='-Wall -Wextra -DNDEBUG -DLIBRARY_LOG_LEVEL=LOG_DEBUG'
+          -DCMAKE_C_FLAGS="${CFLAGS}"
           make -C build/ all
       - name: System Tests
         run: |
@@ -34,12 +36,14 @@ jobs:
       - name: Build
         run: |
           sudo apt-get install -y lcov
+          CFLAGS="--coverage -Wall -Wextra -DNDEBUG"
+          CFLAGS+=" -fsanitize=address,undefined"
           cmake -S test -B build/ \
           -G "Unix Makefiles" \
           -DCMAKE_BUILD_TYPE=Debug \
           -DBUILD_CLONE_SUBMODULES=ON \
           -DUNIT_TESTS=1 \
-          -DCMAKE_C_FLAGS='--coverage -Wall -Wextra -DNDEBUG'
+          -DCMAKE_C_FLAGS="${CFLAGS}"
           make -C build/ all
       - name: Unit Tests
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,6 +28,26 @@ jobs:
         run: |
           cd build/
           ctest --output-on-failure
+  unit-tests-with-sanitizer:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Clone This Repo
+        uses: actions/checkout@v2
+      - name: Build
+        run: |
+          CFLAGS="-Wall -Wextra -DNDEBUG"
+          CFLAGS+=" -fsanitize=address,undefined"
+          cmake -S test -B build/ \
+          -G "Unix Makefiles" \
+          -DCMAKE_BUILD_TYPE=Debug \
+          -DBUILD_CLONE_SUBMODULES=ON \
+          -DUNIT_TESTS=1 \
+          -DCMAKE_C_FLAGS="${CFLAGS}"
+          make -C build/ all
+      - name: Unit Tests
+        run: |
+          cd build/
+          ctest --output-on-failure
   unit-tests:
     runs-on: ubuntu-latest
     steps:
@@ -37,7 +57,6 @@ jobs:
         run: |
           sudo apt-get install -y lcov
           CFLAGS="--coverage -Wall -Wextra -DNDEBUG"
-          #CFLAGS+=" -fsanitize=address,undefined"
           cmake -S test -B build/ \
           -G "Unix Makefiles" \
           -DCMAKE_BUILD_TYPE=Debug \

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,5 @@
 # Change Log for corePKCS11 Library
+- [#129](https://github.com/FreeRTOS/corePKCS11/pull/129) Enable address sanitizer for tests in PR Checks.
 - [#128](https://github.com/FreeRTOS/corePKCS11/pull/128) Fix invalid memory read in system tests.
 - [#126](https://github.com/FreeRTOS/corePKCS11/pull/126) Add default values for configuration macros.
 - [#125](https://github.com/FreeRTOS/corePKCS11/pull/125) Fix memory leaks in corePKCS11.

--- a/test/unit-test/core_pkcs11_mbedtls_utest.c
+++ b/test/unit-test/core_pkcs11_mbedtls_utest.c
@@ -1379,7 +1379,7 @@ void test_pkcs11_C_CreateObjectECPrivKeyBadAtt( void )
         TEST_ASSERT_EQUAL( CKR_ARGUMENTS_BAD, xResult );
 
         xPrivateKeyTemplate[ 2 ].type = CKA_LABEL;
-        xPrivateKeyTemplate[ 5 ].pValue = &pucPrivLabel;
+        xPrivateKeyTemplate[ 5 ].pValue = pucPrivLabel;
         xResult = C_CreateObject( xSession,
                                   ( CK_ATTRIBUTE_PTR ) &xPrivateKeyTemplate,
                                   sizeof( xPrivateKeyTemplate ) / sizeof( CK_ATTRIBUTE ),

--- a/test/unit-test/core_pkcs11_utest.c
+++ b/test/unit-test/core_pkcs11_utest.c
@@ -642,12 +642,24 @@ void test_IotPkcs11_xInitializePkcs11TokenHasTokenInfo( void )
 void test_IotPkcs11_vAppendSHA256AlgorithmIdentifierSequence( void )
 {
     CK_RV xResult = CKR_OK;
-    uint8_t pucMessage[] = pkcs11STUFF_APPENDED_TO_RSA_SIG;
+    uint8_t pucDigestAlgorithmIdentifier[] = pkcs11STUFF_APPENDED_TO_RSA_SIG;
+    uint8_t pucHashData[ 32 ];
     uint8_t pucOidBuf[ 128 ] = { 0 };
 
-    xResult = vAppendSHA256AlgorithmIdentifierSequence( pucMessage, pucOidBuf );
+    memset( &( pucHashData[ 0 ] ), 0xAB, 32 );
+
+    xResult = vAppendSHA256AlgorithmIdentifierSequence( pucHashData, pucOidBuf );
 
     TEST_ASSERT_EQUAL( CKR_OK, xResult );
+    TEST_ASSERT_EQUAL_UINT8_ARRAY( &( pucDigestAlgorithmIdentifier[ 0 ] ),
+                                   &( pucOidBuf[ 0 ] ),
+                                   sizeof( pucDigestAlgorithmIdentifier ) );
+    TEST_ASSERT_EQUAL_UINT8_ARRAY( &( pucHashData[ 0 ] ),
+                                   &( pucOidBuf[ sizeof( pucDigestAlgorithmIdentifier ) ] ),
+                                   32 );
+    TEST_ASSERT_EACH_EQUAL_UINT8( 0,
+                                  &( pucOidBuf[ sizeof( pucDigestAlgorithmIdentifier ) + 32 ] ),
+                                  128 - ( sizeof( pucDigestAlgorithmIdentifier ) + 32 ) );
 }
 
 /*!


### PR DESCRIPTION
This PR enables address sanitizer for unit tests and system tests. It also fixes the 2 issues reported by the sanitizer in unit tests:

1. Update `test_IotPkcs11_vAppendSHA256AlgorithmIdentifierSequence` to avoid invalid memory read and add additional asserts to check the function correctly updated the output parameter.
2. Update `test_pkcs11_C_CreateObjectECPrivKeyBadAtt` to correctly pass ointer value.