### PR TITLE
Rename master to main in docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ These projects implement the PKCS #11 interface on real hardware and have simila
 
 * ARM's [Platform Security Architecture](https://github.com/Linaro/freertos-pkcs11-psa).
 * Microchip's [cryptoauthlib](https://github.com/MicrochipTech/cryptoauthlib).
-* Infineon's [Optiga Trust X](https://github.com/aws/amazon-freertos/blob/master/vendors/infineon/secure_elements/pkcs11/iot_pkcs11_trustx.c).
+* Infineon's [Optiga Trust X](https://github.com/aws/amazon-freertos/blob/main/vendors/infineon/secure_elements/pkcs11/iot_pkcs11_trustx.c).
 
 ## Documentation
 

--- a/source/include/core_pkcs11_config_defaults.h
+++ b/source/include/core_pkcs11_config_defaults.h
@@ -306,7 +306,7 @@
  * double parentheses to be ISO C89/C90 standard compliant.
  * For a reference implementation of the logging macros in POSIX environment,
  * refer to core_pkcs11_config.h files, and the logging-stack in demos folder of the
- * [AWS IoT Embedded C SDK repository](https://github.com/aws/aws-iot-device-sdk-embedded-C/tree/master).
+ * [AWS IoT Embedded C SDK repository](https://github.com/aws/aws-iot-device-sdk-embedded-C/tree/main).
  *
  * <b>Default value</b>: Error logging is turned off, and no code is generated for calls
  * to the macro in the corePKCS11 library on compilation.
@@ -326,7 +326,7 @@
  * double parentheses to be ISO C89/C90 standard compliant.
  * For a reference implementation of the logging macros in POSIX environment,
  * refer to core_pkcs11_config.h files, and the logging-stack in demos folder of the
- * [AWS IoT Embedded C SDK repository](https://github.com/aws/aws-iot-device-sdk-embedded-C/tree/master).
+ * [AWS IoT Embedded C SDK repository](https://github.com/aws/aws-iot-device-sdk-embedded-C/tree/main).
  *
  * <b>Default value</b>: Warning logs are turned off, and no code is generated for calls
  * to the macro in the corePKCS11 library on compilation.
@@ -346,7 +346,7 @@
  * double parentheses to be ISO C89/C90 standard compliant.
  * For a reference implementation of the logging macros in POSIX environment,
  * refer to core_pkcs11_config.h files, and the logging-stack in demos folder of the
- * [AWS IoT Embedded C SDK repository](https://github.com/aws/aws-iot-device-sdk-embedded-C/tree/master).
+ * [AWS IoT Embedded C SDK repository](https://github.com/aws/aws-iot-device-sdk-embedded-C/tree/main).
  *
  * <b>Default value</b>: Info logging is turned off, and no code is generated for calls
  * to the macro in the corePKCS11 library on compilation.
@@ -366,7 +366,7 @@
  * double parentheses to be ISO C89/C90 standard compliant.
  * For a reference implementation of the logging macros in POSIX environment,
  * refer to core_pkcs11_config.h files, and the logging-stack in demos folder of the
- * [AWS IoT Embedded C SDK repository](https://github.com/aws/aws-iot-device-sdk-embedded-C/tree/master).
+ * [AWS IoT Embedded C SDK repository](https://github.com/aws/aws-iot-device-sdk-embedded-C/tree/main).
  *
  * <b>Default value</b>: Debug logging is turned off, and no code is generated for calls
  * to the macro in the corePKCS11 library on compilation.


### PR DESCRIPTION
Renames references to `master` to `main`
