### PR TITLE
Delete broken symlink

### DIFF
--- a/test/cbmc/proofs/prepare.py
+++ b/test/cbmc/proofs/prepare.py
@@ -1,1 +1,0 @@
-../aws-templates-for-cbmc-proofs/template-for-repository/proofs/prepare.py


### PR DESCRIPTION
`test/cbmc/proofs/prepare.py` is a symlink to a file that no longer exists. Thus it should be removed.
This PR fixes the failure in the release script due to the zip not having a corresponding file since the link has non-existent target.