### PR TITLE
Bump mbedtls submodule to v2.28.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,6 @@
 # Change Log for corePKCS11 Library
+## Changes in `main`
+* [#144](http://github.com/FreeRTOS/corePKCS11/pull/144) Update mbedtls submodule to [v2.28.0](https://github.com/ARMmbed/mbedtls/tree/v2.28.0)
 
 ## v3.3.0 (November 2021)
 * [#137](https://github.com/FreeRTOS/corePKCS11/pull/137) Fix code in winsim PAL missed in prior refactor.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,5 @@
 # Change Log for corePKCS11 Library
+
 ## Changes in `main`
 * [#144](http://github.com/FreeRTOS/corePKCS11/pull/144) Update mbedtls submodule to [v2.28.0](https://github.com/ARMmbed/mbedtls/tree/v2.28.0)
 

--- a/docs/doxygen/pages.dox
+++ b/docs/doxygen/pages.dox
@@ -56,7 +56,7 @@ is a software based implementation of the PKCS #11 standard, to allow for writin
 Currently, the software based corePKCS11 library has the following dependencies:
 - The API defined by the PKCS #11 specification. The headers used can be found [here](https://github.com/amazon-freertos/pkcs11/tree/v2.40_errata01).
 - The PKCS #11 PAL layer. This is used for writing PKCS #11 objects to flash.
-- [Mbed TLS](https://github.com/ARMmbed/mbedtls/tree/v2.26.0). This library uses Mbed TLS for the cryptographic logic. Some examples include parsing key and certificate objects, signing operations, and creating digests.
+- [Mbed TLS](https://github.com/ARMmbed/mbedtls/tree/v2.28.0). This library uses Mbed TLS for the cryptographic logic. Some examples include parsing key and certificate objects, signing operations, and creating digests.
 - The standard C library `string.h`, for memory manipulation.
 
 @dot "PKCS #11 implementation direct dependencies"

--- a/manifest.yml
+++ b/manifest.yml
@@ -4,7 +4,7 @@ description: |
   "Software implementation of the PKCS #11 standard.\n"
 dependencies:
   - name : "mbedtls"
-    version: "v2.26.0"
+    version: "v2.28.0"
     repository:
       type: "git"
       url: "https://github.com/ARMmbed/mbedtls/"


### PR DESCRIPTION
*Description*:
Bump mbedtls submodule to latest 2.28.0 release
