### PR TITLE
Reduce level of log printed for noneexistant file

### DIFF
--- a/source/portable/os/posix/core_pkcs11_pal.c
+++ b/source/portable/os/posix/core_pkcs11_pal.c
@@ -60,7 +60,7 @@ static CK_RV prvFileExists( const char * pcFileName )
     if( pxFile == NULL )
     {
         xReturn = CKR_OBJECT_HANDLE_INVALID;
-        LogInfo( ( "Could not open %s for reading.", pcFileName ) );
+        LogDebug( ( "File %s does not exist or could not opened for reading.", pcFileName ) );
     }
     else
     {


### PR DESCRIPTION
Whenever corePKCS11 would check for a file it would log that it could not open the file. This is fine since it just means a new file will be needed, though causes confusion when reading logs as it seems to be an error. This rewords it to not seem like an error and reduces to LogDebug.