### PR TITLE
Update pkcs11_interface_stubs to be compatible with CBMC 5.45+

### DIFF
--- a/test/cbmc/stubs/pkcs11_interface_stubs.c
+++ b/test/cbmc/stubs/pkcs11_interface_stubs.c
@@ -26,6 +26,7 @@
  */
 
 #include <stddef.h>
+#include <string.h>
 
 #include "core_pkcs11.h"
 #include "pkcs11.h"
@@ -56,10 +57,13 @@ CK_DECLARE_FUNCTION( CK_RV, C_GetSlotList )( CK_BBOOL tokenPresent,
     return CKR_OK;
 }
 
+static CK_FUNCTION_LIST prvP11FunctionList = { NULL };
+
 CK_DECLARE_FUNCTION( CK_RV, C_GetFunctionList )( CK_FUNCTION_LIST_PTR_PTR ppFunctionList )
 {
     CK_RV xResult;
-    static CK_FUNCTION_LIST prvP11FunctionList =
+
+    CK_FUNCTION_LIST xP11FunctionList =
     {
         { CRYPTOKI_VERSION_MAJOR, CRYPTOKI_VERSION_MINOR },
         nondet_bool() ? C_Initialize : NULL,
@@ -100,7 +104,7 @@ CK_DECLARE_FUNCTION( CK_RV, C_GetFunctionList )( CK_FUNCTION_LIST_PTR_PTR ppFunc
         NULL, /*C_Decrypt*/
         NULL, /*C_DecryptUpdate*/
         NULL, /*C_DecryptFinal*/
-        nondet_bool() ? C_FindObjectsFinal : NULL,
+        nondet_bool() ? C_DigestInit : NULL,
         NULL, /*C_Digest*/
         nondet_bool() ? C_DigestUpdate : NULL,
         NULL, /* C_DigestKey*/
@@ -132,6 +136,8 @@ CK_DECLARE_FUNCTION( CK_RV, C_GetFunctionList )( CK_FUNCTION_LIST_PTR_PTR ppFunc
         NULL, /*C_CancelFunction*/
         NULL  /*C_WaitForSlotEvent*/
     };
+
+    ( void ) memcpy( &prvP11FunctionList, &xP11FunctionList, sizeof( CK_FUNCTION_LIST ) );
 
     if( xResult == CKR_OK )
     {


### PR DESCRIPTION
Verified the CBMC failure with the existing main branch with cbmc 5.50.0. Also verified that this change fixes the problem on MacOS.