### PR TITLE
Update mbedtls to the latest upstream revisions

### DIFF
--- a/docs/doxygen/include/size_table.md
+++ b/docs/doxygen/include/size_table.md
@@ -20,11 +20,11 @@
     <tr>
         <td>core_pkcs11_mbedtls.c</td>
         <td><center>8.9K</center></td>
-        <td><center>7.4K</center></td>
+        <td><center>7.5K</center></td>
     </tr>
     <tr>
         <td><b>Total estimates</b></td>
         <td><b><center>10.2K</center></b></td>
-        <td><b><center>8.5K</center></b></td>
+        <td><b><center>8.6K</center></b></td>
     </tr>
 </table>

--- a/test/mbedtls_integration/mbedtls_integration_test.c
+++ b/test/mbedtls_integration/mbedtls_integration_test.c
@@ -84,14 +84,6 @@ typedef struct RsaParams_t
  * prevent memory leaks in the case of TEST_PROTECT() actions being triggered. */
 CK_SESSION_HANDLE globalSession = 0;
 CK_FUNCTION_LIST_PTR globalFunctionList = NULL_PTR;
-CK_SLOT_ID globalSlotId = 0;
-CK_MECHANISM_TYPE globalMechanismType = 0;
-
-
-/* PKCS #11 Global Data Containers. */
-CK_BYTE rsaHashedMessage[ pkcs11SHA256_DIGEST_LENGTH ] = { 0 };
-CK_BYTE ecdsaSignature[ pkcs11RSA_2048_SIGNATURE_LENGTH ] = { 0x00 };
-CK_BYTE ecdsaHashedMessage[ pkcs11SHA256_DIGEST_LENGTH ] = { 0xab };
 
 /*-----------------------------------------------------------*/
 
@@ -986,7 +978,6 @@ static void commonVerifySign_RSA( const char * pPrivateKeyLabel,
 {
     CK_RV result;
     CK_OBJECT_HANDLE privateKeyHandle;
-    CK_OBJECT_HANDLE publicKeyHandle;
     CK_OBJECT_HANDLE certificateHandle;
     CK_MECHANISM mechanism;
     CK_BYTE hashedMessage[ pkcs11SHA256_DIGEST_LENGTH ] = { 0 };

--- a/test/pkcs11_mbedtls_utest/core_pkcs11_mbedtls_config.yml
+++ b/test/pkcs11_mbedtls_utest/core_pkcs11_mbedtls_config.yml
@@ -26,6 +26,7 @@
     - <stdint.h>
     - <stddef.h>
     - <fcntl.h>
+    - psa/crypto_types.h
     - mock_osal.h
   :treat_externs: :exclude  # Now the extern-ed functions will be mocked.co
   :weak: __attribute__((weak))

--- a/test/wrapper_utest/core_pkcs11_utest.c
+++ b/test/wrapper_utest/core_pkcs11_utest.c
@@ -120,6 +120,8 @@ static uint16_t usMallocFreeCalls = 0;
 void * pvPkcs11MallocCb( size_t size,
                          int numCalls )
 {
+    ( void ) numCalls;
+
     usMallocFreeCalls++;
     return ( void * ) malloc( size );
 }
@@ -135,6 +137,8 @@ void * pvPkcs11MallocCbFailEveryOtherCall( size_t size,
 {
     static uint32_t ulCalls = 1;
     void * pvReturn = NULL;
+
+    ( void ) numCalls;
 
     ulCalls++;
 
@@ -154,6 +158,8 @@ void * pvPkcs11MallocCbFailEveryOtherCall( size_t size,
 void vPkcs11FreeCb( void * ptr,
                     int numCalls )
 {
+    ( void ) numCalls;
+
     usMallocFreeCalls--;
     free( ptr );
 }
@@ -204,6 +210,8 @@ static CK_RV prvSetFunctionList2( CK_FUNCTION_LIST_PTR_PTR ppxPtr )
 static CK_RV prvUninitializedToken( CK_SLOT_ID slotID,
                                     CK_TOKEN_INFO_PTR pInfo )
 {
+    ( void ) slotID;
+
     pInfo->flags = CKF_TOKEN_INITIALIZED;
     return CKR_OK;
 }
@@ -219,6 +227,10 @@ static CK_RV xSecondGetFails( CK_BBOOL arg1,
 {
     static uint32_t ulCalls = 1;
     CK_RV xResult = CKR_OK;
+
+    ( void ) arg1;
+    ( void ) arg2;
+    ( void ) arg3;
 
     ulCalls++;
 
@@ -239,6 +251,9 @@ static CK_RV xGet1Item( CK_BBOOL arg1,
                         CK_SLOT_ID_PTR arg2,
                         CK_ULONG_PTR arg3 )
 {
+    ( void ) arg1;
+    ( void ) arg2;
+
     *arg3 = 1;
     return CKR_OK;
 }
@@ -253,6 +268,10 @@ static CK_RV xGet1Item2( CK_BBOOL arg1,
                          CK_ULONG_PTR arg3,
                          CK_ULONG_PTR arg4 )
 {
+    ( void ) arg1;
+    ( void ) arg2;
+    ( void ) arg3;
+
     *arg4 = 1;
     return CKR_OK;
 }

--- a/tools/0001-Fix-missing-prototype-warning-when-MBEDTLS_DEPRECATE.patch
+++ b/tools/0001-Fix-missing-prototype-warning-when-MBEDTLS_DEPRECATE.patch
@@ -1,0 +1,48 @@
+From e76d44bc8b4ee892fc15da7cfe094b345311ef95 Mon Sep 17 00:00:00 2001
+From: Aditya Patwardhan <aditya.patwardhan@espressif.com>
+Date: Tue, 26 Jul 2022 14:31:46 +0530
+Subject: [PATCH] Fix missing prototype warning when
+ `MBEDTLS_DEPRECATED_REMOVED` is enabled
+
+Added the changelog.d entry
+
+Signed-off-by: Aditya Patwardhan <aditya.patwardhan@espressif.com>
+(cherry picked from commit 3096f331ee17a37529f6cc12984d82fc077a4f4d)
+---
+ ChangeLog.d/fix_build_error_for_mbedtls_deprecated_removed.txt | 3 +++
+ library/ssl_tls.c                                              | 2 ++
+ 2 files changed, 5 insertions(+)
+ create mode 100644 ChangeLog.d/fix_build_error_for_mbedtls_deprecated_removed.txt
+
+diff --git a/ChangeLog.d/fix_build_error_for_mbedtls_deprecated_removed.txt b/ChangeLog.d/fix_build_error_for_mbedtls_deprecated_removed.txt
+new file mode 100644
+index 000000000..a70521a00
+--- /dev/null
++++ b/ChangeLog.d/fix_build_error_for_mbedtls_deprecated_removed.txt
+@@ -0,0 +1,3 @@
++Bugfix
++    * Fix build error due to missing prototype
++      warning when MBEDTLS_DEPRECATED_REMOVED is enabled
+diff --git a/library/ssl_tls.c b/library/ssl_tls.c
+index e60b82fa5..f594ab5cd 100644
+--- a/library/ssl_tls.c
++++ b/library/ssl_tls.c
+@@ -2309,6 +2309,7 @@ void mbedtls_ssl_get_dtls_srtp_negotiation_result( const mbedtls_ssl_context *ss
+ }
+ #endif /* MBEDTLS_SSL_DTLS_SRTP */
+ 
++#if !defined(MBEDTLS_DEPRECATED_REMOVED)
+ void mbedtls_ssl_conf_max_version( mbedtls_ssl_config *conf, int major, int minor )
+ {
+     conf->max_tls_version = (major << 8) | minor;
+@@ -2318,6 +2319,7 @@ void mbedtls_ssl_conf_min_version( mbedtls_ssl_config *conf, int major, int mino
+ {
+     conf->min_tls_version = (major << 8) | minor;
+ }
++#endif /* MBEDTLS_DEPRECATED_REMOVED */
+ 
+ #if defined(MBEDTLS_SSL_SRV_C)
+ void mbedtls_ssl_conf_cert_req_ca_list( mbedtls_ssl_config *conf,
+-- 
+2.37.3
+

--- a/tools/0001-Fix-missing-prototype-warning-when-MBEDTLS_DEPRECATE.patch
+++ b/tools/0001-Fix-missing-prototype-warning-when-MBEDTLS_DEPRECATE.patch
@@ -30,7 +30,7 @@ index e60b82fa5..f594ab5cd 100644
 @@ -2309,6 +2309,7 @@ void mbedtls_ssl_get_dtls_srtp_negotiation_result( const mbedtls_ssl_context *ss
  }
  #endif /* MBEDTLS_SSL_DTLS_SRTP */
- 
+
 +#if !defined(MBEDTLS_DEPRECATED_REMOVED)
  void mbedtls_ssl_conf_max_version( mbedtls_ssl_config *conf, int major, int minor )
  {
@@ -40,9 +40,8 @@ index e60b82fa5..f594ab5cd 100644
      conf->min_tls_version = (major << 8) | minor;
  }
 +#endif /* MBEDTLS_DEPRECATED_REMOVED */
- 
+
  #if defined(MBEDTLS_SSL_SRV_C)
  void mbedtls_ssl_conf_cert_req_ca_list( mbedtls_ssl_config *conf,
--- 
+--
 2.37.3
-

--- a/tools/mbedtls.cmake
+++ b/tools/mbedtls.cmake
@@ -50,7 +50,7 @@ if(NOT TARGET MbedTLS2_mbedtls)
     add_library(MbedTLS2::interface ALIAS MbedTLS2_interface)
 endif()
 
-set(MBEDTLS_3_VERSION 3.1.0)
+set(MBEDTLS_3_VERSION 3.2.1)
 
 FetchContent_Declare(
     mbedtls_3

--- a/tools/mbedtls.cmake
+++ b/tools/mbedtls.cmake
@@ -1,6 +1,6 @@
 include(FetchContent)
 
-set(MBEDTLS_2_VERSION 2.28.0)
+set(MBEDTLS_2_VERSION 2.28.1)
 
 FetchContent_Declare(
     mbedtls_2

--- a/tools/mbedtls.cmake
+++ b/tools/mbedtls.cmake
@@ -1,5 +1,7 @@
 include(FetchContent)
 
+set(FETCHCONTENT_QUIET OFF)
+
 set(MBEDTLS_2_VERSION 2.28.1)
 
 FetchContent_Declare(
@@ -56,7 +58,9 @@ FetchContent_Declare(
     mbedtls_3
     GIT_REPOSITORY "https://github.com/ARMmbed/mbedtls"
     GIT_TAG v${MBEDTLS_3_VERSION}
-    PATCH_COMMAND ${MODULE_ROOT_DIR}/tools/mbedtls_configure.sh <SOURCE_DIR> mbedtls_config.h
+    PATCH_COMMAND
+        ${CMAKE_CURRENT_LIST_DIR}/mbedtls_configure.sh <SOURCE_DIR> mbedtls_config.h &&
+        ${CMAKE_CURRENT_LIST_DIR}/mbedtls_patch.sh <SOURCE_DIR> ${CMAKE_CURRENT_LIST_DIR}/0001-Fix-missing-prototype-warning-when-MBEDTLS_DEPRECATE.patch
 )
 
 FetchContent_GetProperties(

--- a/tools/mbedtls_configure.sh
+++ b/tools/mbedtls_configure.sh
@@ -1,12 +1,28 @@
 #!/bin/sh
+
+if [ $# -ne 2 ]; then
+    echo "Usage: mbedtls_configure.sh <MBEDTLS_SRC_DIR> <CONFIG_H_NAME>"
+    exit 1
+fi
+
 MBEDTLS_DIR="${1}"
 CONFIG="${2}"
 
-cp $MBEDTLS_DIR/include/mbedtls/$CONFIG mbedtls_config_patch.h
-$MBEDTLS_DIR/scripts/config.py --file mbedtls_config_patch.h full_no_deprecated
-$MBEDTLS_DIR/scripts/config.py --file mbedtls_config_patch.h unset MBEDTLS_PSA_CRYPTO_BUILTIN_KEYS
-$MBEDTLS_DIR/scripts/config.py --file mbedtls_config_patch.h unset MBEDTLS_ENTROPY_NV_SEED
-$MBEDTLS_DIR/scripts/config.py --file mbedtls_config_patch.h unset MBEDTLS_PLATFORM_NV_SEED_ALT
-cmp --quiet $MBEDTLS_DIR/include/mbedtls/config.h mbedtls_config_patch.h || {
-    cp mbedtls_config_patch.h $MBEDTLS_DIR/include/mbedtls/$CONFIG
+cp "${MBEDTLS_DIR}/include/mbedtls/${CONFIG}" mbedtls_config_patch.h
+"${MBEDTLS_DIR}/scripts/config.py" --file mbedtls_config_patch.h full_no_deprecated
+"${MBEDTLS_DIR}/scripts/config.py" --file mbedtls_config_patch.h unset MBEDTLS_PSA_CRYPTO_BUILTIN_KEYS
+"${MBEDTLS_DIR}/scripts/config.py" --file mbedtls_config_patch.h unset MBEDTLS_ENTROPY_NV_SEED
+"${MBEDTLS_DIR}/scripts/config.py" --file mbedtls_config_patch.h unset MBEDTLS_PLATFORM_NV_SEED_ALT
+"${MBEDTLS_DIR}/scripts/config.py" --file mbedtls_config_patch.h unset MBEDTLS_PSA_CRYPTO_C
+"${MBEDTLS_DIR}/scripts/config.py" --file mbedtls_config_patch.h unset MBEDTLS_PSA_CRYPTO_CLIENT
+"${MBEDTLS_DIR}/scripts/config.py" --file mbedtls_config_patch.h unset MBEDTLS_PSA_CRYPTO_DRIVERS
+"${MBEDTLS_DIR}/scripts/config.py" --file mbedtls_config_patch.h unset MBEDTLS_SSL_PROTO_TLS1_3
+"${MBEDTLS_DIR}/scripts/config.py" --file mbedtls_config_patch.h unset MBEDTLS_USE_PSA_CRYPTO
+"${MBEDTLS_DIR}/scripts/config.py" --file mbedtls_config_patch.h unset MBEDTLS_PSA_CRYPTO_C
+"${MBEDTLS_DIR}/scripts/config.py" --file mbedtls_config_patch.h unset MBEDTLS_PSA_CRYPTO_STORAGE_C
+"${MBEDTLS_DIR}/scripts/config.py" --file mbedtls_config_patch.h unset MBEDTLS_PSA_ITS_FILE_C
+"${MBEDTLS_DIR}/scripts/config.py" --file mbedtls_config_patch.h unset MBEDTLS_PSA_CRYPTO_SE_C
+
+cmp --quiet "${MBEDTLS_DIR}/include/mbedtls/config.h" mbedtls_config_patch.h || {
+    cp mbedtls_config_patch.h "${MBEDTLS_DIR}/include/mbedtls/${CONFIG}"
 }

--- a/tools/mbedtls_patch.sh
+++ b/tools/mbedtls_patch.sh
@@ -1,0 +1,28 @@
+#!/bin/sh
+
+if [ $# -lt 2 ]; then
+    echo "Usage: mbedtls_patch.sh <MBEDTLS_SRC_DIR> <PATCH_1> [<PATCH_2>].."
+    exit 1
+fi
+
+MBEDTLS_DIR="${1}"
+
+shift
+
+PATCHES="${1}"
+
+shift
+
+while [ $# -gt 0 ]; do
+    PATCHES="${PATCHES} ${1}"
+    shift
+done
+
+for patch in ${PATCHES}; do
+    if git -C "${MBEDTLS_DIR}" apply --check --quiet --reverse "${patch}"; then
+        echo "patch: $(basename "${patch}") already applied"
+    else
+        echo "patch: applying $(basename "${patch}")"
+        git -C "${MBEDTLS_DIR}" apply "${patch}"
+    fi
+done


### PR DESCRIPTION
Update mbedtls library to v2.28.1 and v3.2.1.

Adjust build files and tests accordingly.