### PR TITLE
Remove mbedtls submodule

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,6 +28,7 @@ jobs:
         run: |
           cd build/
           ctest --output-on-failure
+
   unit-tests-with-sanitizer:
     runs-on: ubuntu-latest
     steps:
@@ -48,6 +49,7 @@ jobs:
         run: |
           cd build/
           ctest --output-on-failure
+
   unit-tests:
     runs-on: ubuntu-latest
     steps:
@@ -82,6 +84,7 @@ jobs:
           path: ./build/coverage.info
           line-coverage-min: 99
           branch-coverage-min: 90
+
   complexity:
     runs-on: ubuntu-latest
     steps:
@@ -92,6 +95,7 @@ jobs:
         run: |
           find source/ -iname '*.c' -not -path 'source/portable/windows/*' -not -path 'source/dependency*' |\
           xargs complexity --scores --threshold=0 --horrid-threshold=8
+
   doxygen:
     runs-on: ubuntu-latest
     steps:
@@ -100,6 +104,7 @@ jobs:
         uses: FreeRTOS/CI-CD-Github-Actions/doxygen@main
         with:
           path: ./
+
   spell-check:
     runs-on: ubuntu-latest
     steps:
@@ -131,6 +136,7 @@ jobs:
           else
             exit 1
           fi
+
   formatting:
     runs-on: ubuntu-20.04
     steps:
@@ -140,6 +146,7 @@ jobs:
         with:
           path: ./
           exclude-dirs: .git
+
   link-verifier:
     runs-on: ubuntu-latest
     steps:
@@ -154,6 +161,7 @@ jobs:
           path: ./
           exclude-dirs: cbmc
           include-file-types: .c,.h,.dox
+
   git-secrets:
     runs-on: ubuntu-latest
     steps:
@@ -170,6 +178,7 @@ jobs:
         run: |
           git-secrets --register-aws
           git-secrets --scan
+
   memory_statistics:
     runs-on: ubuntu-latest
     steps:
@@ -191,6 +200,7 @@ jobs:
         with:
             config: .github/memory_statistics_config.json
             check_against: docs/doxygen/include/size_table.md
+
   proof_ci:
     runs-on: cbmc_ubuntu-latest_16-core
     steps:
@@ -199,13 +209,15 @@ jobs:
         with:
           cbmc_version: "5.61.0"
           cbmc_viewer_version: "3.5"
-      - uses: actions/checkout@v2
-      - name: Update mbedtls submodule
+      - name: Install cmake
         run: |
-          git submodule update --init --checkout --recursive --depth 1
+          sudo apt-get install -y cmake
+      - name: Fetch Mbedtls
+        run: |
+          cd test && cmake -B build
       - name: check for mbedtls header file
         run: |
-          cat source/dependency/3rdparty/mbedtls/include/mbedtls/pk.h
+          cat test/build/_deps/mbedtls_2-src/include/mbedtls/pk.h
       - name: Run CBMC
         uses: FreeRTOS/CI-CD-Github-Actions/run_cbmc@main
         with:

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,8 +1,3 @@
-[submodule "source/dependency/3rdparty/mbedtls"]
-	path = source/dependency/3rdparty/mbedtls
-	url = https://github.com/ARMmbed/mbedtls.git
-	branch = v2.28.0
-	update = none
 [submodule "source/dependency/3rdparty/pkcs11"]
 	path = source/dependency/3rdparty/pkcs11
 	url = https://github.com/amazon-freertos/pkcs11.git

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -18,25 +18,31 @@ get_filename_component(__MODULE_ROOT_DIR "${CMAKE_CURRENT_LIST_DIR}/.." ABSOLUTE
 set(MODULE_ROOT_DIR ${__MODULE_ROOT_DIR} CACHE INTERNAL "corePKCS11 repository root.")
 
 option(SYSTEM_TESTS "Set this to ON to build system tests" ON)
-
 option(UNIT_TESTS "Set this to ON to build unit tests" ON)
+option(COVERITY "Set this to ON to build coverity_analysis target" ON)
 
 # Set output directories.
-set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/bin)
+set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR})
 set(CMAKE_ARCHIVE_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/lib)
 set(CMAKE_LIBRARY_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/lib)
 
 include(${MODULE_ROOT_DIR}/tools/mbedtls.cmake)
-include(${MODULE_ROOT_DIR}/tools/unity.cmake)
-include(${MODULE_ROOT_DIR}/tools/cmock.cmake)
+
+if(UNIT_TESTS OR SYSTEM_TESTS)
+    include(${MODULE_ROOT_DIR}/tools/unity.cmake)
+    include(${MODULE_ROOT_DIR}/tools/cmock.cmake)
+endif()
 
 # ========================================
 # Test Configuration
 # ========================================
 
 # Define a CMock resource path.
-set(CMOCK_DIR ${MODULE_ROOT_DIR}/test/unit-test/CMock CACHE INTERNAL
-                                                            "CMock library source directory."
+set(
+    CMOCK_DIR
+    ${MODULE_ROOT_DIR}/test/unit-test/CMock
+    CACHE INTERNAL
+        "CMock library source directory."
 )
 
 # Use CTest utility for managing test runs. This has to be added BEFORE defining test targets with
@@ -53,22 +59,26 @@ if(SYSTEM_TESTS)
     add_subdirectory(mbedtls_integration)
 endif()
 
-add_subdirectory(coverity_analysis)
+if(COVERITY)
+    add_subdirectory(coverity_analysis)
+endif()
 
 # ========================================
 # Coverage Analysis configuration
 # ========================================
 
-# Add a target for running coverage on tests.
-add_custom_target(
-    coverage
-    COMMAND ${CMAKE_COMMAND} -P ${MODULE_ROOT_DIR}/tools/cmock/coverage.cmake
-    DEPENDS cmock
-            unity
-            $<$<TARGET_EXISTS:core_pkcs11_mbedtls_utest>:core_pkcs11_mbedtls_utest>
-            $<$<TARGET_EXISTS:pkcs11_wrapper_utest>:pkcs11_wrapper_utest>
-            $<$<TARGET_EXISTS:pkcs11_utils_utest>:pkcs11_utils_utest>
-            $<$<TARGET_EXISTS:integration_mbedtls_2>:integration_mbedtls_2>
-            $<$<TARGET_EXISTS:integration_mbedtls_3>:integration_mbedtls_3>
-    WORKING_DIRECTORY ${CMAKE_BINARY_DIR}
-)
+if(UNIT_TESTS OR SYSTEM_TESTS)
+    # Add a target for running coverage on tests.
+    add_custom_target(
+        coverage
+        COMMAND ${CMAKE_COMMAND} -P ${MODULE_ROOT_DIR}/tools/cmock/coverage.cmake
+        DEPENDS cmock
+                unity
+                $<$<TARGET_EXISTS:core_pkcs11_mbedtls_utest>:core_pkcs11_mbedtls_utest>
+                $<$<TARGET_EXISTS:pkcs11_wrapper_utest>:pkcs11_wrapper_utest>
+                $<$<TARGET_EXISTS:pkcs11_utils_utest>:pkcs11_utils_utest>
+                $<$<TARGET_EXISTS:integration_mbedtls_2>:integration_mbedtls_2>
+                $<$<TARGET_EXISTS:integration_mbedtls_3>:integration_mbedtls_3>
+        WORKING_DIRECTORY ${CMAKE_BINARY_DIR}
+    )
+endif()

--- a/test/cbmc/proofs/C_CloseSession/Makefile
+++ b/test/cbmc/proofs/C_CloseSession/Makefile
@@ -9,7 +9,7 @@ HARNESS_FILE = C_CloseSession_harness
 PROOF_UID = C_CloseSession
 
 DEFINES +=
-INCLUDES += -I$(SRCDIR)/source/dependency/3rdparty/mbedtls/include
+INCLUDES += -I$(SRCDIR)/test/build/_deps/mbedtls_2-src/include
 INCLUDES += -I$(SRCDIR)/source/dependency/3rdparty/mbedtls_utils
 
 REMOVE_FUNCTION_BODY += C_Finalize

--- a/test/cbmc/proofs/C_CreateObject/Makefile
+++ b/test/cbmc/proofs/C_CreateObject/Makefile
@@ -28,7 +28,7 @@ MAX_OBJECT_NUM=2
 DEFINES += -DTEMPLATE_SIZE=$(TEMPLATE_SIZE)
 DEFINES += -DTEMPLATE_ATTRIBUTE_MAX_SIZE=$(TEMPLATE_ATTRIBUTE_MAX_SIZE)
 
-INCLUDES += -I$(SRCDIR)/source/dependency/3rdparty/mbedtls/include
+INCLUDES += -I$(SRCDIR)/test/build/_deps/mbedtls_2-src/include
 INCLUDES += -I$(SRCDIR)/source/dependency/3rdparty/mbedtls_utils
 
 REMOVE_FUNCTION_BODY += C_Initialize

--- a/test/cbmc/proofs/C_DestroyObject/Makefile
+++ b/test/cbmc/proofs/C_DestroyObject/Makefile
@@ -16,7 +16,7 @@ MAX_LABEL_SIZE=32
 
 DEFINES += -DMAX_OBJECT_NUM=$(MAX_OBJECT_NUM)
 
-INCLUDES += -I$(SRCDIR)/source/dependency/3rdparty/mbedtls/include
+INCLUDES += -I$(SRCDIR)/test/build/_deps/mbedtls_2-src/include
 INCLUDES += -I$(SRCDIR)/source/dependency/3rdparty/mbedtls_utils
 
 REMOVE_FUNCTION_BODY += C_Finalize

--- a/test/cbmc/proofs/C_DigestFinal/Makefile
+++ b/test/cbmc/proofs/C_DigestFinal/Makefile
@@ -9,7 +9,7 @@ HARNESS_FILE = C_DigestFinal_harness
 PROOF_UID = C_DigestFinal
 
 DEFINES +=
-INCLUDES += -I$(SRCDIR)/source/dependency/3rdparty/mbedtls/include
+INCLUDES += -I$(SRCDIR)/test/build/_deps/mbedtls_2-src/include
 INCLUDES += -I$(SRCDIR)/source/dependency/3rdparty/mbedtls_utils
 
 REMOVE_FUNCTION_BODY +=

--- a/test/cbmc/proofs/C_DigestInit/Makefile
+++ b/test/cbmc/proofs/C_DigestInit/Makefile
@@ -9,7 +9,7 @@ HARNESS_FILE = C_DigestInit_harness
 PROOF_UID = C_DigestInit
 
 DEFINES +=
-INCLUDES += -I$(SRCDIR)/source/dependency/3rdparty/mbedtls/include
+INCLUDES += -I$(SRCDIR)/test/build/_deps/mbedtls_2-src/include
 INCLUDES += -I$(SRCDIR)/source/dependency/3rdparty/mbedtls_utils
 
 REMOVE_FUNCTION_BODY +=

--- a/test/cbmc/proofs/C_DigestUpdate/Makefile
+++ b/test/cbmc/proofs/C_DigestUpdate/Makefile
@@ -9,7 +9,7 @@ HARNESS_FILE = C_DigestUpdate_harness
 PROOF_UID = C_DigestUpdate
 
 DEFINES +=
-INCLUDES += -I$(SRCDIR)/source/dependency/3rdparty/mbedtls/include
+INCLUDES += -I$(SRCDIR)/test/build/_deps/mbedtls_2-src/include
 INCLUDES += -I$(SRCDIR)/source/dependency/3rdparty/mbedtls_utils
 
 REMOVE_FUNCTION_BODY +=

--- a/test/cbmc/proofs/C_Finalize/Makefile
+++ b/test/cbmc/proofs/C_Finalize/Makefile
@@ -9,7 +9,7 @@ HARNESS_FILE = C_Finalize_harness
 PROOF_UID = C_Finalize
 
 DEFINES +=
-INCLUDES += -I$(SRCDIR)/source/dependency/3rdparty/mbedtls/include
+INCLUDES += -I$(SRCDIR)/test/build/_deps/mbedtls_2-src/include
 INCLUDES += -I$(SRCDIR)/source/dependency/3rdparty/mbedtls_utils
 
 REMOVE_FUNCTION_BODY +=

--- a/test/cbmc/proofs/C_FindObjects/Makefile
+++ b/test/cbmc/proofs/C_FindObjects/Makefile
@@ -9,7 +9,7 @@ HARNESS_FILE = C_FindObjects_harness
 PROOF_UID = C_FindObjects
 
 DEFINES +=
-INCLUDES += -I$(SRCDIR)/source/dependency/3rdparty/mbedtls/include
+INCLUDES += -I$(SRCDIR)/test/build/_deps/mbedtls_2-src/include
 INCLUDES += -I$(SRCDIR)/source/dependency/3rdparty/mbedtls_utils
 
 REMOVE_FUNCTION_BODY += C_Finalize

--- a/test/cbmc/proofs/C_FindObjectsFinal/Makefile
+++ b/test/cbmc/proofs/C_FindObjectsFinal/Makefile
@@ -9,7 +9,7 @@ HARNESS_FILE = C_FindObjectsFinal_harness
 PROOF_UID = C_FindObjectsFinal
 
 DEFINES +=
-INCLUDES += -I$(SRCDIR)/source/dependency/3rdparty/mbedtls/include
+INCLUDES += -I$(SRCDIR)/test/build/_deps/mbedtls_2-src/include
 INCLUDES += -I$(SRCDIR)/source/dependency/3rdparty/mbedtls_utils
 
 REMOVE_FUNCTION_BODY +=

--- a/test/cbmc/proofs/C_FindObjectsInit/Makefile
+++ b/test/cbmc/proofs/C_FindObjectsInit/Makefile
@@ -11,7 +11,7 @@ PROOF_UID = C_FindObjectsInit
 TEMPLATE_SIZE=10
 
 DEFINES += -DTEMPLATE_SIZE=$(TEMPLATE_SIZE)
-INCLUDES += -I$(SRCDIR)/source/dependency/3rdparty/mbedtls/include
+INCLUDES += -I$(SRCDIR)/test/build/_deps/mbedtls_2-src/include
 INCLUDES += -I$(SRCDIR)/source/dependency/3rdparty/mbedtls_utils
 
 REMOVE_FUNCTION_BODY +=

--- a/test/cbmc/proofs/C_GenerateKeyPair/Makefile
+++ b/test/cbmc/proofs/C_GenerateKeyPair/Makefile
@@ -12,7 +12,7 @@ TEMPLATE_SIZE=10
 
 DEFINES += -DTEMPLATE_SIZE=$(TEMPLATE_SIZE)
 
-INCLUDES += -I$(SRCDIR)/source/dependency/3rdparty/mbedtls/include
+INCLUDES += -I$(SRCDIR)/test/build/_deps/mbedtls_2-src/include
 INCLUDES += -I$(SRCDIR)/source/dependency/3rdparty/mbedtls_utils
 
 REMOVE_FUNCTION_BODY += C_Initialize

--- a/test/cbmc/proofs/C_GenerateRandom/Makefile
+++ b/test/cbmc/proofs/C_GenerateRandom/Makefile
@@ -9,7 +9,7 @@ HARNESS_FILE = C_GenerateRandom_harness
 PROOF_UID = C_GenerateRandom
 
 DEFINES +=
-INCLUDES += -I$(SRCDIR)/source/dependency/3rdparty/mbedtls/include
+INCLUDES += -I$(SRCDIR)/test/build/_deps/mbedtls_2-src/include
 INCLUDES += -I$(SRCDIR)/source/dependency/3rdparty/mbedtls_utils
 
 REMOVE_FUNCTION_BODY += C_Initialize

--- a/test/cbmc/proofs/C_GetAttributeValue/Makefile
+++ b/test/cbmc/proofs/C_GetAttributeValue/Makefile
@@ -20,7 +20,7 @@ MAX_OBJECT_NUM=2
 
 DEFINES += -DTEMPLATE_SIZE=$(TEMPLATE_SIZE)
 DEFINES += -DMAX_OBJECT_NUM=$(MAX_OBJECT_NUM)
-INCLUDES += -I$(SRCDIR)/source/dependency/3rdparty/mbedtls/include
+INCLUDES += -I$(SRCDIR)/test/build/_deps/mbedtls_2-src/include
 INCLUDES += -I$(SRCDIR)/source/dependency/3rdparty/mbedtls_utils
 
 REMOVE_FUNCTION_BODY +=

--- a/test/cbmc/proofs/C_GetFunctionList/Makefile
+++ b/test/cbmc/proofs/C_GetFunctionList/Makefile
@@ -9,7 +9,7 @@ HARNESS_FILE = C_GetFunctionList_harness
 PROOF_UID = C_GetFunctionList
 
 DEFINES +=
-INCLUDES += -I$(SRCDIR)/source/dependency/3rdparty/mbedtls/include
+INCLUDES += -I$(SRCDIR)/test/build/_deps/mbedtls_2-src/include
 INCLUDES += -I$(SRCDIR)/source/dependency/3rdparty/mbedtls_utils
 
 REMOVE_FUNCTION_BODY +=

--- a/test/cbmc/proofs/C_GetMechanismInfo/Makefile
+++ b/test/cbmc/proofs/C_GetMechanismInfo/Makefile
@@ -9,7 +9,7 @@ HARNESS_FILE = C_GetMechanismInfo_harness
 PROOF_UID = C_GetMechanismInfo
 
 DEFINES +=
-INCLUDES += -I$(SRCDIR)/source/dependency/3rdparty/mbedtls/include
+INCLUDES += -I$(SRCDIR)/test/build/_deps/mbedtls_2-src/include
 INCLUDES += -I$(SRCDIR)/source/dependency/3rdparty/mbedtls_utils
 
 REMOVE_FUNCTION_BODY +=

--- a/test/cbmc/proofs/C_GetSlotList/Makefile
+++ b/test/cbmc/proofs/C_GetSlotList/Makefile
@@ -9,7 +9,7 @@ HARNESS_FILE = C_GetSlotList_harness
 PROOF_UID = C_GetSlotList
 
 DEFINES +=
-INCLUDES += -I$(SRCDIR)/source/dependency/3rdparty/mbedtls/include
+INCLUDES += -I$(SRCDIR)/test/build/_deps/mbedtls_2-src/include
 INCLUDES += -I$(SRCDIR)/source/dependency/3rdparty/mbedtls_utils
 
 # This proof doesn't care about these stubs

--- a/test/cbmc/proofs/C_Initialize/Makefile
+++ b/test/cbmc/proofs/C_Initialize/Makefile
@@ -9,7 +9,7 @@ HARNESS_FILE = C_Initialize_harness
 PROOF_UID = C_Initialize
 
 DEFINES +=
-INCLUDES += -I$(SRCDIR)/source/dependency/3rdparty/mbedtls/include
+INCLUDES += -I$(SRCDIR)/test/build/_deps/mbedtls_2-src/include
 INCLUDES += -I$(SRCDIR)/source/dependency/3rdparty/mbedtls_utils
 
 REMOVE_FUNCTION_BODY += C_Finalize

--- a/test/cbmc/proofs/C_OpenSession/Makefile
+++ b/test/cbmc/proofs/C_OpenSession/Makefile
@@ -9,7 +9,7 @@ HARNESS_FILE = C_OpenSession_harness
 PROOF_UID = C_OpenSession
 
 DEFINES +=
-INCLUDES += -I$(SRCDIR)/source/dependency/3rdparty/mbedtls/include
+INCLUDES += -I$(SRCDIR)/test/build/_deps/mbedtls_2-src/include
 INCLUDES += -I$(SRCDIR)/source/dependency/3rdparty/mbedtls_utils
 
 REMOVE_FUNCTION_BODY += C_Finalize

--- a/test/cbmc/proofs/C_Sign/Makefile
+++ b/test/cbmc/proofs/C_Sign/Makefile
@@ -13,7 +13,7 @@ PROOF_UID = C_Sign
 MAX_OBJECT_NUM=2
 
 DEFINES += -DMAX_OBJECT_NUM=$(MAX_OBJECT_NUM)
-INCLUDES += -I$(SRCDIR)/source/dependency/3rdparty/mbedtls/include
+INCLUDES += -I$(SRCDIR)/test/build/_deps/mbedtls_2-src/include
 INCLUDES += -I$(SRCDIR)/source/dependency/3rdparty/mbedtls_utils
 
 REMOVE_FUNCTION_BODY += C_Initialize

--- a/test/cbmc/proofs/C_SignInit/Makefile
+++ b/test/cbmc/proofs/C_SignInit/Makefile
@@ -13,7 +13,7 @@ PROOF_UID = C_SignInit
 MAX_OBJECT_NUM=2
 
 DEFINES += -DMAX_OBJECT_NUM=$(MAX_OBJECT_NUM)
-INCLUDES += -I$(SRCDIR)/source/dependency/3rdparty/mbedtls/include
+INCLUDES += -I$(SRCDIR)/test/build/_deps/mbedtls_2-src/include
 INCLUDES += -I$(SRCDIR)/source/dependency/3rdparty/mbedtls_utils
 
 REMOVE_FUNCTION_BODY += C_Initialize

--- a/test/cbmc/proofs/C_Verify/Makefile
+++ b/test/cbmc/proofs/C_Verify/Makefile
@@ -13,7 +13,7 @@ PROOF_UID = C_Verify
 MAX_OBJECT_NUM=2
 
 DEFINES += -DMAX_OBJECT_NUM=$(MAX_OBJECT_NUM)
-INCLUDES += -I$(SRCDIR)/source/dependency/3rdparty/mbedtls/include
+INCLUDES += -I$(SRCDIR)/test/build/_deps/mbedtls_2-src/include
 INCLUDES += -I$(SRCDIR)/source/dependency/3rdparty/mbedtls_utils
 
 REMOVE_FUNCTION_BODY += C_Initialize

--- a/test/cbmc/proofs/C_VerifyInit/Makefile
+++ b/test/cbmc/proofs/C_VerifyInit/Makefile
@@ -13,7 +13,7 @@ PROOF_UID = C_VerifyInit
 MAX_OBJECT_NUM=2
 
 DEFINES += -DMAX_OBJECT_NUM=$(MAX_OBJECT_NUM)
-INCLUDES += -I$(SRCDIR)/source/dependency/3rdparty/mbedtls/include
+INCLUDES += -I$(SRCDIR)/test/build/_deps/mbedtls_2-src/include
 INCLUDES += -I$(SRCDIR)/source/dependency/3rdparty/mbedtls_utils
 
 REMOVE_FUNCTION_BODY += C_Initialize


### PR DESCRIPTION
Remove mbedtls submodule, update CBMC CI accordingly

Description
-----------
Remove the mbedtls submodule from the dependencies directory and update the CBMC GitHub actions workflow to use cmake to fetch mbedtls when building cbmc proofs.

Checklist:
----------
- [X] I have tested my changes. No regression in existing tests.
- [X] I have modified and/or added unit-tests to cover the code changes in this Pull Request.
