### PR TITLE
[for fleet provisioning with CSR to support write key and certificate to disk] support optional write generated private key

### DIFF
--- a/source/portable/mbedtls/core_pkcs11_mbedtls.c
+++ b/source/portable/mbedtls/core_pkcs11_mbedtls.c
@@ -55,6 +55,11 @@
 /* C runtime includes. */
 #include <string.h>
 
+#if defined( GENERATED_PRIVATE_KEY_WRITE_PATH )
+    #include <errno.h>
+    #define PRIV_KEY_BUFFER_LENGTH                         2048
+#endif // GENERATED_PRIVATE_KEY_WRITE_PATH
+
 /*-----------------------------------------------------------*/
 
 /**
@@ -5679,8 +5684,6 @@ CK_DECLARE_FUNCTION( CK_RV, C_GenerateKeyPair )( CK_SESSION_HANDLE hSession,
         else
         {
         #if defined( GENERATED_PRIVATE_KEY_WRITE_PATH )
-            #include <errno.h>
-            #define PRIV_KEY_BUFFER_LENGTH                         2048
             char privatekey[ PRIV_KEY_BUFFER_LENGTH ];
             lMbedTLSResult = mbedtls_pk_write_key_pem( &xCtx, privatekey, PRIV_KEY_BUFFER_LENGTH );
             if( lMbedTLSResult == 0 )

--- a/source/portable/mbedtls/core_pkcs11_mbedtls.c
+++ b/source/portable/mbedtls/core_pkcs11_mbedtls.c
@@ -58,7 +58,7 @@
 #if defined( GENERATED_PRIVATE_KEY_WRITE_PATH )
     #include <errno.h>
     #define PRIV_KEY_BUFFER_LENGTH                         2048
-#endif // GENERATED_PRIVATE_KEY_WRITE_PATH
+#endif /* defined( GENERATED_PRIVATE_KEY_WRITE_PATH ) */
 
 /*-----------------------------------------------------------*/
 

--- a/source/portable/mbedtls/core_pkcs11_mbedtls.c
+++ b/source/portable/mbedtls/core_pkcs11_mbedtls.c
@@ -58,7 +58,7 @@
 #if defined( GENERATED_PRIVATE_KEY_WRITE_PATH )
     #warning "GENERATED_PRIVATE_KEY_WRITE_PATH was defined. C_GenerateKeyPair will write generated private keys to that filepath"
     #include <errno.h>
-    #define PRIV_KEY_BUFFER_LENGTH                         2048
+    #define PRIV_KEY_BUFFER_LENGTH    2048
 #endif /* defined( GENERATED_PRIVATE_KEY_WRITE_PATH ) */
 
 /*-----------------------------------------------------------*/
@@ -5684,37 +5684,38 @@ CK_DECLARE_FUNCTION( CK_RV, C_GenerateKeyPair )( CK_SESSION_HANDLE hSession,
         }
         else
         {
-        #if defined( GENERATED_PRIVATE_KEY_WRITE_PATH )
-            char privatekey[ PRIV_KEY_BUFFER_LENGTH ];
-            lMbedTLSResult = mbedtls_pk_write_key_pem( &xCtx, privatekey, PRIV_KEY_BUFFER_LENGTH );
-            if( lMbedTLSResult == 0 )
-            {
-                size_t privatekeyLength = strlen( privatekey );
-                FILE* fp = fopen( GENERATED_PRIVATE_KEY_WRITE_PATH, "w" );
+            #if defined( GENERATED_PRIVATE_KEY_WRITE_PATH )
+                char privatekey[ PRIV_KEY_BUFFER_LENGTH ];
+                lMbedTLSResult = mbedtls_pk_write_key_pem( &xCtx, privatekey, PRIV_KEY_BUFFER_LENGTH );
 
-                if( NULL != fp )
+                if( lMbedTLSResult == 0 )
                 {
-                    const size_t writtenBytes = fwrite( privatekey, 1u, privatekeyLength, fp );
+                    size_t privatekeyLength = strlen( privatekey );
+                    FILE * fp = fopen( GENERATED_PRIVATE_KEY_WRITE_PATH, "w" );
 
-                    if( writtenBytes == privatekeyLength )
+                    if( NULL != fp )
                     {
-                        LogInfo( ( "Wrote the generated private key to %s successfully.", GENERATED_PRIVATE_KEY_WRITE_PATH ) );
+                        const size_t writtenBytes = fwrite( privatekey, 1u, privatekeyLength, fp );
+
+                        if( writtenBytes == privatekeyLength )
+                        {
+                            LogInfo( ( "Wrote the generated private key to %s successfully.", GENERATED_PRIVATE_KEY_WRITE_PATH ) );
+                        }
+                        else
+                        {
+                            LogError( ( "Could not write to %s. Error: %s.", GENERATED_PRIVATE_KEY_WRITE_PATH, strerror( errno ) ) );
+                        }
+
+                        fclose( fp );
                     }
                     else
                     {
-                        LogError( ( "Could not write to %s. Error: %s.", GENERATED_PRIVATE_KEY_WRITE_PATH, strerror( errno ) ) );
+                        LogError( ( "Could not open %s. Error: %s.", GENERATED_PRIVATE_KEY_WRITE_PATH, strerror( errno ) ) );
                     }
-
-                    fclose( fp );
                 }
-                else
-                {
-                    LogError( ( "Could not open %s. Error: %s.", GENERATED_PRIVATE_KEY_WRITE_PATH, strerror( errno ) ) );
-                }
-            }
-        #else /* if defined( GENERATED_PRIVATE_KEY_WRITE_PATH ) */
-            LogInfo( ( "NOTE: define GENERATED_PRIVATE_KEY_WRITE_PATH in order to have the private key written to disk." ) );
-        #endif // GENERATED_PRIVATE_KEY_WRITE_PATH
+            #else /* if defined( GENERATED_PRIVATE_KEY_WRITE_PATH ) */
+                LogInfo( ( "NOTE: define GENERATED_PRIVATE_KEY_WRITE_PATH in order to have the private key written to disk." ) );
+            #endif // GENERATED_PRIVATE_KEY_WRITE_PATH
         }
     }
 

--- a/source/portable/mbedtls/core_pkcs11_mbedtls.c
+++ b/source/portable/mbedtls/core_pkcs11_mbedtls.c
@@ -56,6 +56,7 @@
 #include <string.h>
 
 #if defined( GENERATED_PRIVATE_KEY_WRITE_PATH )
+    #warning "GENERATED_PRIVATE_KEY_WRITE_PATH was defined. C_GenerateKeyPair will write generated private keys to that filepath"
     #include <errno.h>
     #define PRIV_KEY_BUFFER_LENGTH                         2048
 #endif /* defined( GENERATED_PRIVATE_KEY_WRITE_PATH ) */

--- a/source/portable/mbedtls/core_pkcs11_mbedtls.c
+++ b/source/portable/mbedtls/core_pkcs11_mbedtls.c
@@ -5697,7 +5697,7 @@ CK_DECLARE_FUNCTION( CK_RV, C_GenerateKeyPair )( CK_SESSION_HANDLE hSession,
 
                     if( writtenBytes == privatekeyLength )
                     {
-                        LogInfo( ( "Written %s successfully.", GENERATED_PRIVATE_KEY_WRITE_PATH ) );
+                        LogInfo( ( "Wrote the generated private key to %s successfully.", GENERATED_PRIVATE_KEY_WRITE_PATH ) );
                     }
                     else
                     {


### PR DESCRIPTION
Support optional write generated private key to disk

Description
-----------
For use by the fleet provisioning with CSR demo ( see https://github.com/giuspen/aws-iot-device-sdk-embedded-C/tree/GP_fleet_provisioning_with_csr_demo/demos/fleet_provisioning/fleet_provisioning_with_csr ), I would like to support writing key and certificate to disk when the optional macros DOWNLOADED_CERT_WRITE_PATH and GENERATED_PRIVATE_KEY_WRITE_PATH are provided

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have tested my changes. No regression in existing tests.
- [ ] I have modified and/or added unit-tests to cover the code changes in this Pull Request.

