### PR TITLE
Use MBedTLS 3.5.1

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -63,8 +63,8 @@ jobs:
           -DSYSTEM_TESTS=0 \
           -DCMAKE_C_FLAGS="${CFLAGS}"
           make -C build/ all
-          echo "::endgroup::"
 
+          echo "::endgroup::"
           echo -e "${{ env.bashPass }} ${{env.stepName}} ${{ env.bashEnd }}"
 
       - name: Run Unit Tests
@@ -78,6 +78,8 @@ jobs:
 
       - env:
           stepName: Build corePKCS11 Unit Tests
+        id: build-unit-tests
+        shell: bash
         run: |
           # ${{ env.stepName }}
           echo -e "::group::${{ env.bashInfo }} ${{ env.stepName }} ${{ env.bashEnd }}"
@@ -91,15 +93,20 @@ jobs:
           -DSYSTEM_TESTS=0 \
           -DCMAKE_C_FLAGS="${CFLAGS}"
           make -C build/ all
-          echo "::endgroup::"
 
+          echo "::endgroup::"
           echo -e "${{ env.bashPass }} ${{env.stepName}} ${{ env.bashEnd }}"
 
       - name: Run Unit Tests
+        id: run-unit-tests
+        shell: bash
         run: ctest --test-dir build --output-on-failure
 
       - env:
           stepName: Line and Branch Coverage Build
+        if: steps.build-unit-tests.outcome == 'success'
+        id: line-and-branch-coverage
+        shell: bash
         run: |
           # ${{ env.stepName }}
           echo -e "::group::${{ env.bashInfo }} Build Coverage Target ${{ env.bashEnd }}"
@@ -111,11 +118,21 @@ jobs:
           lcov --rc lcov_branch_coverage=1 -r build/coverage.info -o build/coverage.info '*test*' '*CMakeCCompilerId*' '*mocks*'
           echo "::endgroup::"
 
-          lcov --list build/coverage.info
+          lcov --rc lcov_branch_coverage=1 --list build/coverage.info
           echo -e "${{ env.bashPass }} ${{env.stepName}} ${{ env.bashEnd }}"
 
+
+      - env:
+          stepName: Check Coverage
+        uses: FreeRTOS/CI-CD-Github-Actions/coverage-cop@main
+        if: steps.build-unit-tests.outcome == 'success'
+        with:
+          coverage-file: ./build/coverage.info
+          line-coverage-min: 99
+          branch-coverage-min: 90
+
       - name: Archive Test Results
-        if: success() || failure()
+        if: steps.build-unit-tests.outcome == 'success'
         uses: actions/upload-artifact@v3
         with:
           name: unit_test_results
@@ -127,7 +144,7 @@ jobs:
             build/Testing/Temporary/LastTest.log
 
       - name: Upload coverage data to Codecov
-        if: success()
+        if: steps.build-unit-tests.outcome == 'success'
         uses: codecov/codecov-action@v3
         with:
           files: build/coverage.info

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,7 +32,7 @@ jobs:
           make -C build/ all
 
       - name: Integration Tests
-        run:  ctest --test-dir build --output-on-failure | tee -a $GITHUB_STEP_SUMMARY
+        run:  ctest --test-dir build --output-on-failure
 
       - name: Archive Test Results
         if: success() || failure()
@@ -68,7 +68,7 @@ jobs:
           echo -e "${{ env.bashPass }} ${{env.stepName}} ${{ env.bashEnd }}"
 
       - name: Run Unit Tests
-        run: ctest --test-dir build --output-on-failure | tee -a $GITHUB_STEP_SUMMARY
+        run: ctest --test-dir build --output-on-failure
 
   unit-tests:
     runs-on: ubuntu-latest
@@ -96,7 +96,7 @@ jobs:
           echo -e "${{ env.bashPass }} ${{env.stepName}} ${{ env.bashEnd }}"
 
       - name: Run Unit Tests
-        run: ctest --test-dir build --output-on-failure | tee -a $GITHUB_STEP_SUMMARY
+        run: ctest --test-dir build --output-on-failure
 
       - env:
           stepName: Line and Branch Coverage Build

--- a/source/core_pkcs11.c
+++ b/source/core_pkcs11.c
@@ -25,11 +25,13 @@
 #include "core_pkcs11_config.h"
 #include "core_pkcs11_config_defaults.h"
 #include "core_pkcs11.h"
+#include "pkcs11t.h"
 
 /* C runtime includes. */
 #include <stdio.h>
 #include <stdint.h>
 #include <string.h>
+
 
 /**
  * @file core_pkcs11.c
@@ -171,6 +173,9 @@ CK_RV xInitializePKCS11( void )
     if( ( xResult == CKR_OK ) && ( pxFunctionList != NULL ) && ( pxFunctionList->C_Initialize != NULL ) )
     {
         xResult = pxFunctionList->C_Initialize( &xInitArgs );
+    }
+    else{
+        xResult = CKR_DEVICE_ERROR;
     }
 
     return xResult;

--- a/source/core_pkcs11.c
+++ b/source/core_pkcs11.c
@@ -174,7 +174,8 @@ CK_RV xInitializePKCS11( void )
     {
         xResult = pxFunctionList->C_Initialize( &xInitArgs );
     }
-    else{
+    else
+    {
         xResult = CKR_DEVICE_ERROR;
     }
 

--- a/source/core_pkcs11.c
+++ b/source/core_pkcs11.c
@@ -32,7 +32,6 @@
 #include <stdint.h>
 #include <string.h>
 
-
 /**
  * @file core_pkcs11.c
  * @brief corePKCS11 Interface.

--- a/source/portable/mbedtls/core_pkcs11_mbedtls.c
+++ b/source/portable/mbedtls/core_pkcs11_mbedtls.c
@@ -5150,26 +5150,26 @@ CK_DECLARE_FUNCTION( CK_RV, C_Verify )( CK_SESSION_HANDLE hSession,
                     }
                 }
 
-            #ifdef MBEDTLS_ECDSA_C
-                if( xResult == CKR_OK )
-                {
-                    /* Verify the signature. If a public key is present, use it. */
-                    if( NULL != pxSessionObj->xVerifyKey.pk_ctx )
+                #ifdef MBEDTLS_ECDSA_C
+                    if( xResult == CKR_OK )
                     {
-                        pxEcdsaContext = pxSessionObj->xVerifyKey.pk_ctx;
-                        lMbedTLSResult = mbedtls_ecdsa_verify( &pxEcdsaContext->grp, pData, ulDataLen, &pxEcdsaContext->Q, &xR, &xS );
-                    }
+                        /* Verify the signature. If a public key is present, use it. */
+                        if( NULL != pxSessionObj->xVerifyKey.pk_ctx )
+                        {
+                            pxEcdsaContext = pxSessionObj->xVerifyKey.pk_ctx;
+                            lMbedTLSResult = mbedtls_ecdsa_verify( &pxEcdsaContext->grp, pData, ulDataLen, &pxEcdsaContext->Q, &xR, &xS );
+                        }
 
-                    if( lMbedTLSResult != 0 )
-                    {
-                        xResult = CKR_SIGNATURE_INVALID;
-                        LogError( ( "Failed verify operation. "
-                                    "mbedtls_ecdsa_verify failed: mbed TLS error = %s : %s.",
-                                    mbedtlsHighLevelCodeOrDefault( lMbedTLSResult ),
-                                    mbedtlsLowLevelCodeOrDefault( lMbedTLSResult ) ) );
+                        if( lMbedTLSResult != 0 )
+                        {
+                            xResult = CKR_SIGNATURE_INVALID;
+                            LogError( ( "Failed verify operation. "
+                                        "mbedtls_ecdsa_verify failed: mbed TLS error = %s : %s.",
+                                        mbedtlsHighLevelCodeOrDefault( lMbedTLSResult ),
+                                        mbedtlsLowLevelCodeOrDefault( lMbedTLSResult ) ) );
+                        }
                     }
-                }
-            #endif /* MBEDTLS_ECDSA_C */
+                #endif /* MBEDTLS_ECDSA_C */
 
                 mbedtls_mpi_free( &xR );
                 mbedtls_mpi_free( &xS );

--- a/source/portable/mbedtls/core_pkcs11_mbedtls.c
+++ b/source/portable/mbedtls/core_pkcs11_mbedtls.c
@@ -35,6 +35,7 @@
 #include "core_pkcs11.h"
 #include "core_pkcs11_pal.h"
 #include "core_pki_utils.h"
+#include "pkcs11t.h"
 
 /**
  *  @brief Declaring MBEDTLS_ALLOW_PRIVATE_ACCESS allows access to mbedtls "private" fields.
@@ -5149,6 +5150,7 @@ CK_DECLARE_FUNCTION( CK_RV, C_Verify )( CK_SESSION_HANDLE hSession,
                     }
                 }
 
+            #ifdef MBEDTLS_ECDSA_C
                 if( xResult == CKR_OK )
                 {
                     /* Verify the signature. If a public key is present, use it. */
@@ -5167,6 +5169,7 @@ CK_DECLARE_FUNCTION( CK_RV, C_Verify )( CK_SESSION_HANDLE hSession,
                                     mbedtlsLowLevelCodeOrDefault( lMbedTLSResult ) ) );
                     }
                 }
+            #endif /* MBEDTLS_ECDSA_C */
 
                 mbedtls_mpi_free( &xR );
                 mbedtls_mpi_free( &xS );

--- a/source/portable/mbedtls/core_pkcs11_mbedtls.c
+++ b/source/portable/mbedtls/core_pkcs11_mbedtls.c
@@ -42,7 +42,13 @@
  */
 #define MBEDTLS_ALLOW_PRIVATE_ACCESS
 
-/* mbedTLS includes. */
+/* MbedTLS includes. */
+#if defined( MBEDTLS_CONFIG_FILE )
+    #include MBEDTLS_CONFIG_FILE
+#else
+    #include "mbedtls/mbedtls_config.h"
+#endif
+
 #include "mbedtls/pk.h"
 #include "mbedtls/x509_crt.h"
 #include "mbedtls/ctr_drbg.h"
@@ -496,19 +502,24 @@ static CK_RV prvMbedTLS_Initialize( void )
             if( lMbedTLSResult != PSA_SUCCESS )
             {
                 LogError( ( "Could not initialize PKCS #11. Failed to initialize PSA: MBedTLS error = %s : %s.",
-                            mbedtlsHighLevelCodeOrDefault( lMbedTLSResult ),
-                            mbedtlsLowLevelCodeOrDefault( lMbedTLSResult ) ) );
+                    mbedtlsHighLevelCodeOrDefault( lMbedTLSResult ),
+                    mbedtlsLowLevelCodeOrDefault( lMbedTLSResult ) ) );
                 xResult = CKR_FUNCTION_FAILED;
+                /* MISRA Ref 10.5.1 [Essential type casting] */
+                /* More details at: https://github.com/FreeRTOS/corePKCS11/blob/main/MISRA.md#rule-105 */
+                /* coverity[misra_c_2012_rule_10_5_violation] */
+                xP11Context.xIsInitialized = ( CK_BBOOL ) CK_FALSE;
             }
-            else
+            else{
+                LogDebug( ( "MbedTLS PSA module was successfully initialized." ) );
+            }
         #endif /* MBEDTLS_USE_PSA_CRYPTO */
-        {
-            /* MISRA Ref 10.5.1 [Essential type casting] */
-            /* More details at: https://github.com/FreeRTOS/corePKCS11/blob/main/MISRA.md#rule-105 */
-            /* coverity[misra_c_2012_rule_10_5_violation] */
-            xP11Context.xIsInitialized = ( CK_BBOOL ) CK_TRUE;
-            LogDebug( ( "PKCS #11 module was successfully initialized." ) );
-        }
+
+        /* MISRA Ref 10.5.1 [Essential type casting] */
+        /* More details at: https://github.com/FreeRTOS/corePKCS11/blob/main/MISRA.md#rule-105 */
+        /* coverity[misra_c_2012_rule_10_5_violation] */
+        xP11Context.xIsInitialized = ( CK_BBOOL ) CK_TRUE;
+        LogDebug( ( "PKCS #11 module was successfully initialized." ) );
     }
 
     return xResult;

--- a/source/portable/mbedtls/core_pkcs11_mbedtls.c
+++ b/source/portable/mbedtls/core_pkcs11_mbedtls.c
@@ -43,12 +43,6 @@
 #define MBEDTLS_ALLOW_PRIVATE_ACCESS
 
 /* MbedTLS includes. */
-#if defined( MBEDTLS_CONFIG_FILE )
-    #include MBEDTLS_CONFIG_FILE
-#else
-    #include "mbedtls/mbedtls_config.h"
-#endif
-
 #include "mbedtls/pk.h"
 #include "mbedtls/x509_crt.h"
 #include "mbedtls/ctr_drbg.h"

--- a/source/portable/mbedtls/core_pkcs11_mbedtls.c
+++ b/source/portable/mbedtls/core_pkcs11_mbedtls.c
@@ -502,15 +502,16 @@ static CK_RV prvMbedTLS_Initialize( void )
             if( lMbedTLSResult != PSA_SUCCESS )
             {
                 LogError( ( "Could not initialize PKCS #11. Failed to initialize PSA: MBedTLS error = %s : %s.",
-                    mbedtlsHighLevelCodeOrDefault( lMbedTLSResult ),
-                    mbedtlsLowLevelCodeOrDefault( lMbedTLSResult ) ) );
+                            mbedtlsHighLevelCodeOrDefault( lMbedTLSResult ),
+                            mbedtlsLowLevelCodeOrDefault( lMbedTLSResult ) ) );
                 xResult = CKR_FUNCTION_FAILED;
                 /* MISRA Ref 10.5.1 [Essential type casting] */
                 /* More details at: https://github.com/FreeRTOS/corePKCS11/blob/main/MISRA.md#rule-105 */
                 /* coverity[misra_c_2012_rule_10_5_violation] */
                 xP11Context.xIsInitialized = ( CK_BBOOL ) CK_FALSE;
             }
-            else{
+            else
+            {
                 LogDebug( ( "MbedTLS PSA module was successfully initialized." ) );
             }
         #endif /* MBEDTLS_USE_PSA_CRYPTO */
@@ -5161,26 +5162,24 @@ CK_DECLARE_FUNCTION( CK_RV, C_Verify )( CK_SESSION_HANDLE hSession,
                     }
                 }
 
-                #ifdef MBEDTLS_ECDSA_C
-                    if( xResult == CKR_OK )
+                if( xResult == CKR_OK )
+                {
+                    /* Verify the signature. If a public key is present, use it. */
+                    if( NULL != pxSessionObj->xVerifyKey.pk_ctx )
                     {
-                        /* Verify the signature. If a public key is present, use it. */
-                        if( NULL != pxSessionObj->xVerifyKey.pk_ctx )
-                        {
-                            pxEcdsaContext = pxSessionObj->xVerifyKey.pk_ctx;
-                            lMbedTLSResult = mbedtls_ecdsa_verify( &pxEcdsaContext->grp, pData, ulDataLen, &pxEcdsaContext->Q, &xR, &xS );
-                        }
-
-                        if( lMbedTLSResult != 0 )
-                        {
-                            xResult = CKR_SIGNATURE_INVALID;
-                            LogError( ( "Failed verify operation. "
-                                        "mbedtls_ecdsa_verify failed: mbed TLS error = %s : %s.",
-                                        mbedtlsHighLevelCodeOrDefault( lMbedTLSResult ),
-                                        mbedtlsLowLevelCodeOrDefault( lMbedTLSResult ) ) );
-                        }
+                        pxEcdsaContext = pxSessionObj->xVerifyKey.pk_ctx;
+                        lMbedTLSResult = mbedtls_ecdsa_verify( &pxEcdsaContext->grp, pData, ulDataLen, &pxEcdsaContext->Q, &xR, &xS );
                     }
-                #endif /* MBEDTLS_ECDSA_C */
+
+                    if( lMbedTLSResult != 0 )
+                    {
+                        xResult = CKR_SIGNATURE_INVALID;
+                        LogError( ( "Failed verify operation. "
+                                    "mbedtls_ecdsa_verify failed: mbed TLS error = %s : %s.",
+                                    mbedtlsHighLevelCodeOrDefault( lMbedTLSResult ),
+                                    mbedtlsLowLevelCodeOrDefault( lMbedTLSResult ) ) );
+                    }
+                }
 
                 mbedtls_mpi_free( &xR );
                 mbedtls_mpi_free( &xS );

--- a/source/portable/mbedtls/core_pkcs11_mbedtls.c
+++ b/source/portable/mbedtls/core_pkcs11_mbedtls.c
@@ -56,7 +56,7 @@
 #ifdef MBEDTLS_PSA_CRYPTO_C
     #include "psa/crypto.h"
     #include "psa/crypto_values.h"
-#endif
+#endif /* MBEDTLS_PSA_CRYPTO_C */
 
 /* C runtime includes. */
 #include <string.h>
@@ -490,7 +490,7 @@ static CK_RV prvMbedTLS_Initialize( void )
     }
     else
     {
-        #ifdef MBEDTLS_USE_PSA_CRYPTO
+        #ifdef MBEDTLS_PSA_CRYPTO_C
             lMbedTLSResult = psa_crypto_init();
 
             if( lMbedTLSResult != PSA_SUCCESS )
@@ -508,7 +508,7 @@ static CK_RV prvMbedTLS_Initialize( void )
             {
                 LogDebug( ( "MbedTLS PSA module was successfully initialized." ) );
             }
-        #endif /* MBEDTLS_USE_PSA_CRYPTO */
+        #endif /* MBEDTLS_PSA_CRYPTO_C */
 
         /* MISRA Ref 10.5.1 [Essential type casting] */
         /* More details at: https://github.com/FreeRTOS/corePKCS11/blob/main/MISRA.md#rule-105 */

--- a/source/portable/mbedtls/core_pkcs11_mbedtls.c
+++ b/source/portable/mbedtls/core_pkcs11_mbedtls.c
@@ -495,8 +495,8 @@ static CK_RV prvMbedTLS_Initialize( void )
             if( lMbedTLSResult != PSA_SUCCESS )
             {
                 LogError( ( "Could not initialize PKCS #11. Failed to initialize PSA: MBedTLS error = %s : %s.",
-                        mbedtlsHighLevelCodeOrDefault( lMbedTLSResult ),
-                        mbedtlsLowLevelCodeOrDefault( lMbedTLSResult ) ) );
+                            mbedtlsHighLevelCodeOrDefault( lMbedTLSResult ),
+                            mbedtlsLowLevelCodeOrDefault( lMbedTLSResult ) ) );
                 xResult = CKR_FUNCTION_FAILED;
             }
             else

--- a/source/portable/os/freertos_winsim/core_pkcs11_pal.c
+++ b/source/portable/os/freertos_winsim/core_pkcs11_pal.c
@@ -32,26 +32,25 @@
 
 /*-----------------------------------------------------------*/
 
-#ifdef WIN32
-    #ifndef WIN32_LEAN_AND_MEAN
-        #define WIN32_LEAN_AND_MEAN
-    #endif /* WIN32_LEAN_AND_MEAN */
-
-    #include <winsock2.h>
-    #include <windows.h>
-#endif
-
-
-#include "FreeRTOS.h"
-#include "core_pkcs11.h"
-#include "core_pkcs11_config.h"
-#include "core_pkcs11_config_defaults.h"
-
-
-/* C runtime includes. */
+/* System Includes */
 #include <stdio.h>
 #include <string.h>
 
+#ifdef WIN32
+    #ifdef WIN32_LEAN_AND_MEAN
+        #include <winsock2.h>
+    #else
+        #include <winsock.h>
+    #endif /* WIN32_LEAN_AND_MEAN */
+#endif /* WIN32 */
+
+/* FreeRTOS Includes */
+#include "FreeRTOS.h"
+
+/* corePKCS11 Includes */
+#include "core_pkcs11.h"
+#include "core_pkcs11_config.h"
+#include "core_pkcs11_config_defaults.h"
 #include "core_pkcs11_pal_utils.h"
 
 /*-----------------------------------------------------------*/

--- a/source/portable/os/freertos_winsim/core_pkcs11_pal.c
+++ b/source/portable/os/freertos_winsim/core_pkcs11_pal.c
@@ -32,6 +32,16 @@
 
 /*-----------------------------------------------------------*/
 
+#ifdef WIN32
+    #ifndef WIN32_LEAN_AND_MEAN
+        #define WIN32_LEAN_AND_MEAN
+    #endif /* WIN32_LEAN_AND_MEAN */
+
+    #include <winsock2.h>
+    #include <windows.h>
+#endif
+
+
 #include "FreeRTOS.h"
 #include "core_pkcs11.h"
 #include "core_pkcs11_config.h"
@@ -43,15 +53,6 @@
 #include <string.h>
 
 #include "core_pkcs11_pal_utils.h"
-
-#ifdef WIN32
-    #ifndef WIN32_LEAN_AND_MEAN
-        #define WIN32_LEAN_AND_MEAN
-    #endif
-    #include <winsock2.h>
-    #include <windows.h>
-#endif
-
 
 /*-----------------------------------------------------------*/
 

--- a/source/portable/os/freertos_winsim/core_pkcs11_pal.c
+++ b/source/portable/os/freertos_winsim/core_pkcs11_pal.c
@@ -44,6 +44,14 @@
 
 #include "core_pkcs11_pal_utils.h"
 
+#ifdef WIN32
+    #ifndef WIN32_LEAN_AND_MEAN
+        #define WIN32_LEAN_AND_MEAN
+    #endif
+    #include <winsock2.h>
+    #include <windows.h>
+#endif
+
 
 /*-----------------------------------------------------------*/
 

--- a/test/wrapper_utest/core_pkcs11_utest.c
+++ b/test/wrapper_utest/core_pkcs11_utest.c
@@ -343,7 +343,7 @@ void test_IotPkcs11_xInitializePkcs11BadFunctionList( void )
     C_GetFunctionList_IgnoreAndReturn( CKR_ARGUMENTS_BAD );
     xResult = xInitializePKCS11();
 
-    TEST_ASSERT_EQUAL( CKR_ARGUMENTS_BAD, xResult );
+    TEST_ASSERT_EQUAL( CKR_DEVICE_ERROR, xResult );
 }
 
 /*!

--- a/tools/mbedtls.cmake
+++ b/tools/mbedtls.cmake
@@ -52,7 +52,7 @@ if(NOT TARGET MbedTLS2_mbedtls)
     add_library(MbedTLS2::interface ALIAS MbedTLS2_interface)
 endif()
 
-set(MBEDTLS_3_VERSION 3.4.0)
+set(MBEDTLS_3_VERSION 3.5.0)
 
 FetchContent_Declare(
     mbedtls_3

--- a/tools/mbedtls.cmake
+++ b/tools/mbedtls.cmake
@@ -52,7 +52,7 @@ if(NOT TARGET MbedTLS2_mbedtls)
     add_library(MbedTLS2::interface ALIAS MbedTLS2_interface)
 endif()
 
-set(MBEDTLS_3_VERSION 3.5.0)
+set(MBEDTLS_3_VERSION 3.5.1)
 
 FetchContent_Declare(
     mbedtls_3


### PR DESCRIPTION
<!--- Title -->

Description
-----------
Use MBedTLS 3.5.1 for the corePKCS11 MBedTLS tests
Add some new checks to account for the changes
Wrap certain sections related to crypto operations in config checks
Swap the Windows port to use `WIN32_LEAN_AND_MEAN` and `winsock2.h` for compatibility with mbedtls v3.5.1

Test Steps
-----------
<!-- Describe the steps to reproduce. -->
Ran the FreeRTOS-Plus WinSim demos and unit tests in this repository with these changes.

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have tested my changes. No regression in existing tests.
- [x] I have modified and/or added unit-tests to cover the code changes in this Pull Request.

Related Issue
-----------
<!-- If any, please provide issue ID. -->
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
