### PR TITLE
Switch pkcs11 submodule to OASIS repository

### DIFF
--- a/.github/memory_statistics_config.json
+++ b/.github/memory_statistics_config.json
@@ -7,7 +7,7 @@
     ],
     "include": [
         "source/include",
-        "source/dependency/3rdparty/pkcs11",
+        "source/dependency/3rdparty/pkcs11/published/2-40-errata-1",
         "build/_deps/mbedtls_2-src/include",
         "source/dependency/3rdparty/mbedtls_utils",
         "test/include"

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "source/dependency/3rdparty/pkcs11"]
 	path = source/dependency/3rdparty/pkcs11
-	url = https://github.com/amazon-freertos/pkcs11.git
+	url = https://github.com/oasis-tcs/pkcs11.git

--- a/manifest.yml
+++ b/manifest.yml
@@ -5,9 +5,9 @@ license: "MIT"
 
 dependencies:
   - name: "pkcs11"
-    version: "v2.40_errata01"
+    version: "2-40-errata-1"
     license: "OASIS-IPR"
     repository:
       type: "git"
-      url: "https://github.com/amazon-freertos/pkcs11.git"
+      url: "https://github.com/oasis-tcs/pkcs11.git"
       path: "source/dependency/3rdparty/pkcs11"

--- a/pkcsFilePaths.cmake
+++ b/pkcsFilePaths.cmake
@@ -14,7 +14,7 @@ set( PKCS_SOURCES
 
 # corePKCS11 library public include directories.
 set( PKCS_INCLUDE_PUBLIC_DIRS
-     "${CMAKE_CURRENT_LIST_DIR}/source/dependency/3rdparty/pkcs11"
+     "${CMAKE_CURRENT_LIST_DIR}/source/dependency/3rdparty/pkcs11/published/2-40-errata-1"
      "${CMAKE_CURRENT_LIST_DIR}/source/include"
      )
 

--- a/test/cbmc/proofs/Makefile-project-defines
+++ b/test/cbmc/proofs/Makefile-project-defines
@@ -31,7 +31,7 @@ COMPILE_FLAGS += -DMBEDTLS_CONFIG_FILE="<mbedtls_config.h>"
 # INCLUDES =
 INCLUDES += -I$(SRCDIR)/source/include
 INCLUDES += -I$(CBMC_ROOT)/include
-INCLUDES += -I$(SRCDIR)/source/dependency/3rdparty/pkcs11
+INCLUDES += -I$(SRCDIR)/source/dependency/3rdparty/pkcs11/published/2-40-errata-1
 
 # Preprocessor definitions -D...
 # DEFINES =


### PR DESCRIPTION
Description
-----------
Use the pkcs11 repository provided by OASIS instead of the amazon-freertos github organization.

Test Steps
-----------
<!-- Describe the steps to reproduce. -->

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have tested my changes. No regression in existing tests.
- [ ] I have modified and/or added unit-tests to cover the code changes in this Pull Request.

Related Issue
-----------
<!-- If any, please provide issue ID. -->
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
