### PR TITLE
Update coverity version message

### DIFF
--- a/.github/.cSpellWords.txt
+++ b/.github/.cSpellWords.txt
@@ -24,6 +24,7 @@ CSDK
 CSRS
 ctest
 DCMOCK
+DCOV
 decihours
 Decihours
 DECIHOURS
@@ -32,6 +33,7 @@ DNDEBUG
 Drbg
 DSYSTEM
 DUNIT
+DUNITTEST
 DUNITY
 ecdh
 ecjpake

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,7 +27,7 @@ jobs:
           -G "Unix Makefiles" \
           -DCMAKE_BUILD_TYPE=Debug \
           -DSYSTEM_TESTS=1 \
-          -DUNIT_TESTS=0 \
+          -DUNITTEST=0 \
           -DCMAKE_C_FLAGS="${CFLAGS}"
           make -C build/ all
 
@@ -59,7 +59,7 @@ jobs:
           cmake -S test -B build/ \
           -G "Unix Makefiles" \
           -DCMAKE_BUILD_TYPE=Debug \
-          -DUNIT_TESTS=1 \
+          -DUNITTEST=1 \
           -DSYSTEM_TESTS=0 \
           -DCMAKE_C_FLAGS="${CFLAGS}"
           make -C build/ all
@@ -89,7 +89,7 @@ jobs:
           cmake -S test -B build/ \
           -G "Unix Makefiles" \
           -DCMAKE_BUILD_TYPE=Debug \
-          -DUNIT_TESTS=1 \
+          -DUNITTEST=1 \
           -DSYSTEM_TESTS=0 \
           -DCMAKE_C_FLAGS="${CFLAGS}"
           make -C build/ all
@@ -240,7 +240,7 @@ jobs:
         run: |
           cmake -S test -B build/ \
           -G "Unix Makefiles" \
-          -DUNIT_TESTS=0 \
+          -DUNITTEST=0 \
           -DSYSTEM_TESTS=0 \
           -DCMAKE_C_FLAGS="${CFLAGS}"
       - name: Install Python3

--- a/README.md
+++ b/README.md
@@ -137,7 +137,7 @@ Coverage builds are validated on recent versions of Ubuntu Linux.
 
    - You may specify your preferred build tool by appending `-G'Unix Makefiles'`
      or `-GNinja` to the command above.
-   - You may append `-DUNIT_TESTS=0` or `-DSYSTEM_TESTS=0` to disable Unit Tests
+   - You may append `-DUNITTEST=0` or `-DSYSTEM_TESTS=0` to disable Unit Tests
      or Integration Tests respectively.
 
 1. Build the test binaries: `cmake --build ./build --target all`

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -1,5 +1,7 @@
 cmake_minimum_required(VERSION 3.13.0)
-project("corePKCS11 tests" LANGUAGES C)
+project( "corePKCS11 tests"
+         VERSION 3.5.0
+         LANGUAGES C)
 
 # Allow the project to be organized into folders.
 set_property(GLOBAL PROPERTY USE_FOLDERS ON)
@@ -18,8 +20,8 @@ get_filename_component(__MODULE_ROOT_DIR "${CMAKE_CURRENT_LIST_DIR}/.." ABSOLUTE
 set(MODULE_ROOT_DIR ${__MODULE_ROOT_DIR} CACHE INTERNAL "corePKCS11 repository root.")
 
 option(SYSTEM_TESTS "Set this to ON to build system tests" ON)
-option(UNIT_TESTS "Set this to ON to build unit tests" ON)
-option(COVERITY "Set this to ON to build coverity_analysis target" ON)
+option(UNITTEST "Set this to ON to build unit tests" ON)
+option(COV_ANALYSIS "Set this to ON to build coverity_analysis target" ON)
 
 # Set output directories.
 set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR})
@@ -28,7 +30,7 @@ set(CMAKE_LIBRARY_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/lib)
 
 include(${MODULE_ROOT_DIR}/tools/mbedtls.cmake)
 
-if(UNIT_TESTS OR SYSTEM_TESTS)
+if(UNITTEST OR SYSTEM_TESTS)
     include(${MODULE_ROOT_DIR}/tools/unity.cmake)
     include(${MODULE_ROOT_DIR}/tools/cmock.cmake)
 endif()
@@ -49,7 +51,7 @@ set(
 # add_test()
 enable_testing()
 
-if(UNIT_TESTS)
+if(UNITTEST)
     add_subdirectory(pkcs11_mbedtls_utest)
     add_subdirectory(pkcs11_utils_utest)
     add_subdirectory(wrapper_utest)
@@ -59,7 +61,7 @@ if(SYSTEM_TESTS)
     add_subdirectory(mbedtls_integration)
 endif()
 
-if(COVERITY)
+if(COV_ANALYSIS)
     add_subdirectory(coverity_analysis)
 endif()
 
@@ -67,7 +69,7 @@ endif()
 # Coverage Analysis configuration
 # ========================================
 
-if(UNIT_TESTS OR SYSTEM_TESTS)
+if(UNITTEST OR SYSTEM_TESTS)
     # Add a target for running coverage on tests.
     add_custom_target(
         coverage

--- a/tools/coverity/README.md
+++ b/tools/coverity/README.md
@@ -5,7 +5,7 @@ To that end, this directory provides a [configuration file](https://github.com/F
 building a binary for the tool to analyze.
 
 > **Note**
-For generating the report as outlined below, we have used Coverity version 2018.09.
+For generating the report as outlined below, we have used Coverity version 2023.6.1.
 
 For details regarding the suppressed violations in the report (which can be generated using the instructions described below), please
 see the [MISRA.md](https://github.com/FreeRTOS/corePKCS11/blob/main/MISRA.md) file.
@@ -31,7 +31,7 @@ Go to the root directory of the library and run the following commands in termin
   ~~~
 2. Create the build files using CMake in a `build` directory
   ~~~
-  cmake -B build -S test
+  cmake -B build -S test -DCOV_ANALYSIS=1
   ~~~
 3. Go to the build directory and copy the coverity configuration file
   ~~~
@@ -62,7 +62,7 @@ Go to the root directory of the library and run the following commands in termin
 For your convenience the commands above are below to be copy/pasted into a UNIX command friendly terminal.
  ~~~
  cov-configure --force --compiler cc --comptype gcc;
- cmake -B build -S test;
+ cmake -B build -S test -DCOV_ANALYSIS=1;
  cd build/;
  cov-build --emit-complementary-info --dir cov-out make coverity_analysis;
  cd cov-out/


### PR DESCRIPTION
Update coverity version message

Description
-----------
In this PR:
* Update coverity version to 2023.6.1
* Replace CMake variable "UNIT_TESTS" with "UNITTEST", "COVERITY" with "COV_ANALYSIS" to align with FreeRTOS libraries

Test Steps
-----------
<!-- Describe the steps to reproduce. -->

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have tested my changes. No regression in existing tests.
- [ ] ~~I have modified and/or added unit-tests to cover the code changes in this Pull Request.~~

Related Issue
-----------
<!-- If any, please provide issue ID. -->
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
