### PR TITLE
Fix mbedtls c get attribute value

### DIFF
--- a/source/portable/mbedtls/core_pkcs11_mbedtls.c
+++ b/source/portable/mbedtls/core_pkcs11_mbedtls.c
@@ -3355,6 +3355,7 @@ CK_DECLARE_FUNCTION( CK_RV, C_GetAttributeValue )( CK_SESSION_HANDLE hSession,
                                                                           ( uint8_t * ) pTemplate[ iAttrib ].pValue + 1,
                                                                           pTemplate[ iAttrib ].ulValueLen - 1UL );
                             xSize = xMbedSize;
+
                             if( lMbedTLSResult < 0 )
                             {
                                 if( lMbedTLSResult == MBEDTLS_ERR_ECP_BUFFER_TOO_SMALL )
@@ -5905,4 +5906,3 @@ CK_DECLARE_FUNCTION( CK_RV, C_GenerateRandom )( CK_SESSION_HANDLE hSession,
     return xResult;
 }
 /* @[declare_pkcs11_mbedtls_c_generate_random] */
-

--- a/test/pkcs11_mbedtls_utest/core_pkcs11_mbedtls_utest.c
+++ b/test/pkcs11_mbedtls_utest/core_pkcs11_mbedtls_utest.c
@@ -3271,8 +3271,9 @@ void test_pkcs11_C_GetAttributeValueAttParsing( void )
  * { CKR_OK, CKR_FUNCTION_FAILED } : Return value is CKR_FUNCTION_FAILED.
  * { CKR_FUNCTION_FAILED, CKR_OK } : Return value is CKR_FUNCTION_FAILED and the
  * second attribute is not returned in the implementation.
- * { CKR_FUNCTION_FAILED, CKR_ATTRIBUTE_TYPE_INVALID } : Return value is CKR_FUNCTION_FAILED
- * { CKR_ATTRIBUTE_TYPE_INVALID, CKR_FUNCTION_FAILED } : Return value is CKR_FUNCTION_FAILED
+ * { CKR_FUNCTION_FAILED, CKR_ATTRIBUTE_TYPE_INVALID } : Return value is CKR_FUNCTION_FAILED and the
+ * second attribute is not returned in the implementation.
+ * { CKR_ATTRIBUTE_TYPE_INVALID, CKR_FUNCTION_FAILED } : Return value is CKR_FUNCTION_FAILED.
  */
 void test_pkcs11_C_GetAttributeValueMultipleAttParsing( void )
 {

--- a/test/pkcs11_mbedtls_utest/core_pkcs11_mbedtls_utest.c
+++ b/test/pkcs11_mbedtls_utest/core_pkcs11_mbedtls_utest.c
@@ -3157,7 +3157,6 @@ void test_pkcs11_C_GetAttributeValueAttParsing( void )
 
         xResult = C_GetAttributeValue( xSession, xObject, ( CK_ATTRIBUTE_PTR ) &xTemplate, ulCount );
         TEST_ASSERT_EQUAL( CKR_OK, xResult );
-
         TEST_ASSERT_EQUAL( pkcs11EC_POINT_LENGTH, xTemplate.ulValueLen );
 
         xTemplate.pValue = &ulPoint;
@@ -3173,6 +3172,7 @@ void test_pkcs11_C_GetAttributeValueAttParsing( void )
         mbedtls_ecp_tls_write_point_IgnoreAndReturn( MBEDTLS_ERR_ECP_BUFFER_TOO_SMALL );
         xResult = C_GetAttributeValue( xSession, xObject, ( CK_ATTRIBUTE_PTR ) &xTemplate, ulCount );
         TEST_ASSERT_EQUAL( CKR_BUFFER_TOO_SMALL, xResult );
+        TEST_ASSERT_EQUAL( CK_UNAVAILABLE_INFORMATION, xTemplate.ulValueLen );
 
         mbedtls_ecp_tls_write_point_IgnoreAndReturn( -1 );
         xTemplate.pValue = &ulPoint;
@@ -3180,6 +3180,7 @@ void test_pkcs11_C_GetAttributeValueAttParsing( void )
 
         xResult = C_GetAttributeValue( xSession, xObject, ( CK_ATTRIBUTE_PTR ) &xTemplate, ulCount );
         TEST_ASSERT_EQUAL( CKR_FUNCTION_FAILED, xResult );
+        TEST_ASSERT_EQUAL( CK_UNAVAILABLE_INFORMATION, xTemplate.ulValueLen );
 
         mbedtls_ecp_tls_write_point_IgnoreAndReturn( 1 );
 
@@ -3188,6 +3189,7 @@ void test_pkcs11_C_GetAttributeValueAttParsing( void )
 
         xResult = C_GetAttributeValue( xSession, xObject, ( CK_ATTRIBUTE_PTR ) &xTemplate, ulCount );
         TEST_ASSERT_EQUAL( CKR_ATTRIBUTE_TYPE_INVALID, xResult );
+        TEST_ASSERT_EQUAL( CK_UNAVAILABLE_INFORMATION, xTemplate.ulValueLen );
 
         /* CKA Class Case */
         xTemplate.type = CKA_CLASS;
@@ -3231,7 +3233,7 @@ void test_pkcs11_C_GetAttributeValueAttParsing( void )
         mbedtls_pk_parse_key_IgnoreAndReturn( 0 );
         xResult = C_GetAttributeValue( xSession, xObjectPub, ( CK_ATTRIBUTE_PTR ) &xTemplate, ulCount );
         TEST_ASSERT_EQUAL( CKR_BUFFER_TOO_SMALL, xResult );
-        TEST_ASSERT_EQUAL( 0, xTemplate.ulValueLen );
+        TEST_ASSERT_EQUAL( CK_UNAVAILABLE_INFORMATION, xTemplate.ulValueLen );
 
         xTemplate.type = CKA_VALUE;
         xTemplate.pValue = &ulLength;
@@ -3350,17 +3352,17 @@ void test_pkcs11_C_GetAttributeValuePrivKey( void )
 
         xTemplate.type = CKA_CLASS;
         xTemplate.ulValueLen = 0;
-        ulCount = 2;
         mbedtls_pk_parse_key_ExpectAnyArgsAndReturn( 0 );
         xResult = C_GetAttributeValue( xSession, xObject, ( CK_ATTRIBUTE_PTR ) &xTemplate, ulCount );
         TEST_ASSERT_EQUAL( CKR_BUFFER_TOO_SMALL, xResult );
-
+        TEST_ASSERT_EQUAL( CK_UNAVAILABLE_INFORMATION, xTemplate.ulValueLen );
 
         xTemplate.type = CKA_KEY_TYPE;
+        xTemplate.ulValueLen = 0;
         mbedtls_pk_parse_key_ExpectAnyArgsAndReturn( 0 );
         xResult = C_GetAttributeValue( xSession, xObject, ( CK_ATTRIBUTE_PTR ) &xTemplate, ulCount );
         TEST_ASSERT_EQUAL( CKR_BUFFER_TOO_SMALL, xResult );
-
+        TEST_ASSERT_EQUAL( CK_UNAVAILABLE_INFORMATION, xTemplate.ulValueLen );
 
         xTemplate.ulValueLen = sizeof( CKA_KEY_TYPE );
         ulCount = 1;
@@ -3369,12 +3371,13 @@ void test_pkcs11_C_GetAttributeValuePrivKey( void )
         xPkType = MBEDTLS_PK_NONE;
         xResult = C_GetAttributeValue( xSession, xObject, ( CK_ATTRIBUTE_PTR ) &xTemplate, ulCount );
         TEST_ASSERT_EQUAL( CKR_ATTRIBUTE_VALUE_INVALID, xResult );
+        TEST_ASSERT_EQUAL( CK_UNAVAILABLE_INFORMATION, xTemplate.ulValueLen );
 
         xTemplate.type = CKA_PRIVATE_EXPONENT;
         mbedtls_pk_parse_key_ExpectAnyArgsAndReturn( 0 );
         xResult = C_GetAttributeValue( xSession, xObject, ( CK_ATTRIBUTE_PTR ) &xTemplate, ulCount );
         TEST_ASSERT_EQUAL( CKR_ATTRIBUTE_SENSITIVE, xResult );
-
+        TEST_ASSERT_EQUAL( CK_UNAVAILABLE_INFORMATION, xTemplate.ulValueLen );
 
         xTemplate.type = CKA_EC_PARAMS;
         xTemplate.pValue = NULL;
@@ -3388,6 +3391,7 @@ void test_pkcs11_C_GetAttributeValuePrivKey( void )
         mbedtls_pk_parse_key_ExpectAnyArgsAndReturn( 0 );
         xResult = C_GetAttributeValue( xSession, xObject, ( CK_ATTRIBUTE_PTR ) &xTemplate, ulCount );
         TEST_ASSERT_EQUAL( CKR_BUFFER_TOO_SMALL, xResult );
+        TEST_ASSERT_EQUAL( CK_UNAVAILABLE_INFORMATION, xTemplate.ulValueLen );
 
         xTemplate.type = CKA_EC_POINT;
         xTemplate.pValue = &ulCount;
@@ -3395,12 +3399,14 @@ void test_pkcs11_C_GetAttributeValuePrivKey( void )
         mbedtls_pk_parse_key_ExpectAnyArgsAndReturn( 0 );
         xResult = C_GetAttributeValue( xSession, xObject, ( CK_ATTRIBUTE_PTR ) &xTemplate, ulCount );
         TEST_ASSERT_EQUAL( CKR_BUFFER_TOO_SMALL, xResult );
+        TEST_ASSERT_EQUAL( CK_UNAVAILABLE_INFORMATION, xTemplate.ulValueLen );
 
         xTemplate.pValue = &xKeyType;
         xTemplate.ulValueLen = 0;
         mbedtls_pk_parse_key_ExpectAnyArgsAndReturn( 0 );
         xResult = C_GetAttributeValue( xSession, xObject, ( CK_ATTRIBUTE_PTR ) &xTemplate, ulCount );
         TEST_ASSERT_EQUAL( CKR_BUFFER_TOO_SMALL, xResult );
+        TEST_ASSERT_EQUAL( CK_UNAVAILABLE_INFORMATION, xTemplate.ulValueLen );
     }
 
     if( TEST_PROTECT() )


### PR DESCRIPTION
<!--- Title -->

Description
-----------
This PR address the issue #170 to fix mbedtls C_GetAttributeValue implementation
* ulValueLen is set to CK_UNAVAILABLE_INFORMATION if the attributes for the object can't be obtained.
* Attributes in the templates will be processed when error codes are CKR_ATTRIBUTE_SENSITIVE, CKR_ATTRIBUTE_TYPE_INVALID, or CKR_BUFFER_TOO_SMALL.

Reference [PKCS11-base-v2.40](http://docs.oasis-open.org/pkcs11/pkcs11-base/v2.40/os/pkcs11-base-v2.40-os.doc)

Test Steps
-----------
Verify in the unit test.

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have tested my changes. No regression in existing tests.
- [x] I have modified and/or added unit-tests to cover the code changes in this Pull Request.

Related Issue
-----------
#170 
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
