### PR TITLE
Add more unit test to cover code_pkcs11.c

### DIFF
--- a/docs/doxygen/include/size_table.md
+++ b/docs/doxygen/include/size_table.md
@@ -10,7 +10,7 @@
     <tr>
         <td>core_pkcs11.c</td>
         <td><center>0.8K</center></td>
-        <td><center>0.8K</center></td>
+        <td><center>0.7K</center></td>
     </tr>
     <tr>
         <td>core_pki_utils.c</td>
@@ -25,6 +25,6 @@
     <tr>
         <td><b>Total estimates</b></td>
         <td><b><center>10.3K</center></b></td>
-        <td><b><center>8.6K</center></b></td>
+        <td><b><center>8.5K</center></b></td>
     </tr>
 </table>

--- a/source/core_pkcs11.c
+++ b/source/core_pkcs11.c
@@ -164,21 +164,24 @@ CK_RV xInitializePkcs11Token( void )
     CK_FLAGS xTokenFlags = 0;
     CK_TOKEN_INFO_PTR pxTokenInfo = NULL;
 
-    xResult = C_GetFunctionList( &pxFunctionList );
-
-    if( ( pxFunctionList == NULL ) || ( pxFunctionList->C_GetTokenInfo == NULL ) || ( pxFunctionList->C_InitToken == NULL ) )
-    {
-        xResult = CKR_FUNCTION_FAILED;
-    }
-
-    if( xResult == CKR_OK )
-    {
-        xResult = xInitializePKCS11();
-    }
+    xResult = xInitializePKCS11();
 
     if( ( xResult == CKR_OK ) || ( xResult == CKR_CRYPTOKI_ALREADY_INITIALIZED ) )
     {
         xResult = xGetSlotList( &pxSlotId, &xSlotCount );
+    }
+
+    if( xResult == CKR_OK )
+    {
+        xResult = C_GetFunctionList( &pxFunctionList );
+
+        if( xResult == CKR_OK )
+        {
+            if( ( pxFunctionList == NULL ) || ( pxFunctionList->C_GetTokenInfo == NULL ) || ( pxFunctionList->C_InitToken == NULL ) )
+            {
+                xResult = CKR_FUNCTION_FAILED;
+            }
+        }
     }
 
     if( xResult == CKR_OK )

--- a/source/core_pkcs11.c
+++ b/source/core_pkcs11.c
@@ -41,35 +41,6 @@
 
 /*-----------------------------------------------------------*/
 
-/** @brief Open a PKCS #11 Session.
- *
- *  \param[out] pxSession   Pointer to the session handle to be created.
- *  \param[out] xSlotId     Slot ID to be used for the session.
- *
- *  \return CKR_OK or PKCS #11 error code. (PKCS #11 error codes are positive).
- */
-static CK_RV prvOpenSession( CK_SESSION_HANDLE * pxSession,
-                             CK_SLOT_ID xSlotId )
-{
-    CK_RV xResult;
-    CK_FUNCTION_LIST_PTR pxFunctionList;
-
-    xResult = C_GetFunctionList( &pxFunctionList );
-
-    if( ( xResult == CKR_OK ) && ( pxFunctionList != NULL ) && ( pxFunctionList->C_OpenSession != NULL ) )
-    {
-        xResult = pxFunctionList->C_OpenSession( xSlotId,
-                                                 CKF_SERIAL_SESSION | CKF_RW_SESSION,
-                                                 NULL, /* Application defined pointer. */
-                                                 NULL, /* Callback function. */
-                                                 pxSession );
-    }
-
-    return xResult;
-}
-
-/*-----------------------------------------------------------*/
-
 CK_RV xGetSlotList( CK_SLOT_ID ** ppxSlotId,
                     CK_ULONG * pxSlotCount )
 {
@@ -210,9 +181,7 @@ CK_RV xInitializePkcs11Token( void )
         xResult = xGetSlotList( &pxSlotId, &xSlotCount );
     }
 
-    if( ( xResult == CKR_OK ) &&
-        ( NULL != pxFunctionList->C_GetTokenInfo ) &&
-        ( NULL != pxFunctionList->C_InitToken ) )
+    if( xResult == CKR_OK )
     {
         /* Check if the token requires further initialization. */
         /* MISRA Ref 11.5.1 [Void pointer assignment] */
@@ -270,11 +239,19 @@ CK_RV xInitializePkcs11Session( CK_SESSION_HANDLE * pxSession )
     CK_FUNCTION_LIST_PTR pxFunctionList = NULL;
     CK_ULONG xSlotCount = 0;
 
-    xResult = C_GetFunctionList( &pxFunctionList );
-
     if( pxSession == NULL )
     {
         xResult = CKR_ARGUMENTS_BAD;
+    }
+
+    if( xResult == CKR_OK )
+    {
+        xResult = C_GetFunctionList( &pxFunctionList );
+
+        if( ( xResult == CKR_OK ) && ( pxFunctionList == NULL ) )
+        {
+            xResult = CKR_FUNCTION_FAILED;
+        }
     }
 
     /* Initialize the module. */
@@ -295,19 +272,30 @@ CK_RV xInitializePkcs11Session( CK_SESSION_HANDLE * pxSession )
     }
 
     /* Open a PKCS #11 session. */
-    if( ( xResult == CKR_OK ) && ( pxSlotId != NULL ) && ( xSlotCount >= 1UL ) )
+    if( ( xResult == CKR_OK ) && ( xSlotCount >= 1UL ) )
     {
         /* We will take the first slot available.
          * If your application has multiple slots, insert logic
          * for selecting an appropriate slot here.
          */
-        xResult = prvOpenSession( pxSession, pxSlotId[ 0 ] );
+        if( pxFunctionList->C_OpenSession != NULL )
+        {
+            xResult = pxFunctionList->C_OpenSession( pxSlotId[ 0 ],
+                                                     CKF_SERIAL_SESSION | CKF_RW_SESSION,
+                                                     NULL, /* Application defined pointer. */
+                                                     NULL, /* Callback function. */
+                                                     pxSession );
+        }
+        else
+        {
+            xResult = CKR_FUNCTION_FAILED;
+        }
 
         /* Free the memory allocated by xGetSlotList. */
         pkcs11configPKCS11_FREE( pxSlotId );
     }
 
-    if( ( xResult == CKR_OK ) && ( pxFunctionList != NULL ) && ( pxFunctionList->C_Login != NULL ) )
+    if( ( xResult == CKR_OK ) && ( pxFunctionList->C_Login != NULL ) )
     {
         xResult = pxFunctionList->C_Login( *pxSession,
                                            CKU_USER,

--- a/test/wrapper_utest/core_pkcs11_utest.c
+++ b/test/wrapper_utest/core_pkcs11_utest.c
@@ -947,3 +947,63 @@ void test_IotPkcs11_xFindObjectWithLabelAndClassBadFunctionList( void )
 
     TEST_ASSERT_EQUAL( CKR_FUNCTION_FAILED, xResult );
 }
+
+/*!
+ * @brief xFindObjectWithLabelAndClass no C_FindObjectsInit.
+ *
+ */
+void test_IotPkcs11_xFindObjectWithLabelAndClassNoC_FindObjectsInit( void )
+{
+    CK_RV xResult = CKR_OK;
+    CK_SESSION_HANDLE xHandle = { 0 };
+    CK_OBJECT_HANDLE xPrivateKeyHandle = { 0 };
+
+    vCommonStubs();
+    prvP11FunctionList.C_FindObjectsInit = NULL;
+    xResult = xFindObjectWithLabelAndClass( xHandle,
+                                            pkcs11configLABEL_DEVICE_CERTIFICATE_FOR_TLS,
+                                            strlen( pkcs11configLABEL_DEVICE_CERTIFICATE_FOR_TLS ),
+                                            CKO_PRIVATE_KEY, &xPrivateKeyHandle );
+    prvP11FunctionList.C_FindObjectsInit = C_FindObjectsInit;
+    TEST_ASSERT_EQUAL( CKR_FUNCTION_FAILED, xResult );
+}
+
+/*!
+ * @brief xFindObjectWithLabelAndClass no C_FindObjects.
+ *
+ */
+void test_IotPkcs11_xFindObjectWithLabelAndClassNoC_FindObjects( void )
+{
+    CK_RV xResult = CKR_OK;
+    CK_SESSION_HANDLE xHandle = { 0 };
+    CK_OBJECT_HANDLE xPrivateKeyHandle = { 0 };
+
+    vCommonStubs();
+    prvP11FunctionList.C_FindObjects = NULL;
+    xResult = xFindObjectWithLabelAndClass( xHandle,
+                                            pkcs11configLABEL_DEVICE_CERTIFICATE_FOR_TLS,
+                                            strlen( pkcs11configLABEL_DEVICE_CERTIFICATE_FOR_TLS ),
+                                            CKO_PRIVATE_KEY, &xPrivateKeyHandle );
+    prvP11FunctionList.C_FindObjects = C_FindObjects;
+    TEST_ASSERT_EQUAL( CKR_FUNCTION_FAILED, xResult );
+}
+
+/*!
+ * @brief xFindObjectWithLabelAndClass no C_FindObjectsFinal.
+ *
+ */
+void test_IotPkcs11_xFindObjectWithLabelAndClassNoC_FindObjectsFinal( void )
+{
+    CK_RV xResult = CKR_OK;
+    CK_SESSION_HANDLE xHandle = { 0 };
+    CK_OBJECT_HANDLE xPrivateKeyHandle = { 0 };
+
+    vCommonStubs();
+    prvP11FunctionList.C_FindObjectsFinal = NULL;
+    xResult = xFindObjectWithLabelAndClass( xHandle,
+                                            pkcs11configLABEL_DEVICE_CERTIFICATE_FOR_TLS,
+                                            strlen( pkcs11configLABEL_DEVICE_CERTIFICATE_FOR_TLS ),
+                                            CKO_PRIVATE_KEY, &xPrivateKeyHandle );
+    prvP11FunctionList.C_FindObjectsFinal = C_FindObjectsFinal;
+    TEST_ASSERT_EQUAL( CKR_FUNCTION_FAILED, xResult );
+}


### PR DESCRIPTION
<!--- Title -->

Description
-----------
Add more unit test to cover code_pkcs11.c
In this PR:
* Code coverage for core_pkcs11.c is now 100%
* Remove local function `prvOpenSession` since it is only used in `xInitializePkcs11Session` and `pxFunctionList` is already obtained in this function.
* Remove redundant functional pointer check in `xInitializePkcs11Token`.
* Add more `C_GetFunctionList` check

Test Steps
-----------
N/A

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have tested my changes. No regression in existing tests.
- [ ] I have modified and/or added unit-tests to cover the code changes in this Pull Request.

Related Issue
-----------
<!-- If any, please provide issue ID. -->
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
