### PR TITLE
Add more unit test for core_pkcs11_mbedtls.c

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -128,7 +128,7 @@ jobs:
         if: steps.build-unit-tests.outcome == 'success'
         with:
           coverage-file: ./build/coverage.info
-          line-coverage-min: 99
+          line-coverage-min: 100
           branch-coverage-min: 90
 
       - name: Archive Test Results

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -130,7 +130,7 @@ jobs:
         with:
           coverage-file: ./build/coverage.info
           line-coverage-min: 100
-          branch-coverage-min: 90
+          branch-coverage-min: 92
 
       - name: Archive Test Results
         if: steps.build-unit-tests.outcome == 'success'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -85,7 +85,8 @@ jobs:
           echo -e "::group::${{ env.bashInfo }} ${{ env.stepName }} ${{ env.bashEnd }}"
 
           sudo apt-get install -y lcov
-          CFLAGS="--coverage -Wall -Wextra -DNDEBUG"
+          # target_enable_gcov is added in each unit test already, --coverage option is not required
+          CFLAGS="-Wall -Wextra -DNDEBUG"
           cmake -S test -B build/ \
           -G "Unix Makefiles" \
           -DCMAKE_BUILD_TYPE=Debug \
@@ -128,7 +129,7 @@ jobs:
         if: steps.build-unit-tests.outcome == 'success'
         with:
           coverage-file: ./build/coverage.info
-          line-coverage-min: 99
+          line-coverage-min: 100
           branch-coverage-min: 90
 
       - name: Archive Test Results

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -128,7 +128,7 @@ jobs:
         if: steps.build-unit-tests.outcome == 'success'
         with:
           coverage-file: ./build/coverage.info
-          line-coverage-min: 100
+          line-coverage-min: 99
           branch-coverage-min: 90
 
       - name: Archive Test Results

--- a/docs/doxygen/include/size_table.md
+++ b/docs/doxygen/include/size_table.md
@@ -25,6 +25,6 @@
     <tr>
         <td><b>Total estimates</b></td>
         <td><b><center>10.3K</center></b></td>
-        <td><b><center>8.5K</center></b></td>
+        <td><b><center>8.4K</center></b></td>
     </tr>
 </table>

--- a/docs/doxygen/include/size_table.md
+++ b/docs/doxygen/include/size_table.md
@@ -20,11 +20,11 @@
     <tr>
         <td>core_pkcs11_mbedtls.c</td>
         <td><center>9.0K</center></td>
-        <td><center>7.5K</center></td>
+        <td><center>7.4K</center></td>
     </tr>
     <tr>
         <td><b>Total estimates</b></td>
         <td><b><center>10.3K</center></b></td>
-        <td><b><center>8.6K</center></b></td>
+        <td><b><center>8.5K</center></b></td>
     </tr>
 </table>

--- a/source/portable/mbedtls/core_pkcs11_mbedtls.c
+++ b/source/portable/mbedtls/core_pkcs11_mbedtls.c
@@ -762,15 +762,9 @@ static CK_RV prvRsaContextParse( const CK_ATTRIBUTE * pxAttribute,
             lMbedTLSResult = mbedtls_mpi_read_binary( &pxRsaContext->DQ, pxAttribute->pValue, pxAttribute->ulValueLen );
             break;
 
-        case ( CKA_COEFFICIENT ):
-            lMbedTLSResult = mbedtls_mpi_read_binary( &pxRsaContext->QP, pxAttribute->pValue, pxAttribute->ulValueLen );
-            break;
-
         default:
-
-            /* This should never be reached, as the above types are what gets this function called.
-             * Nevertheless this is an error case, and MISRA requires a default statement. */
-            xResult = CKR_ATTRIBUTE_TYPE_INVALID;
+            /* This is the CKA_COEFFICIENT case. The type is ckecked in prvRsaKeyAttParse. */
+            lMbedTLSResult = mbedtls_mpi_read_binary( &pxRsaContext->QP, pxAttribute->pValue, pxAttribute->ulValueLen );
             break;
     }
 
@@ -3449,7 +3443,7 @@ CK_DECLARE_FUNCTION( CK_RV, C_FindObjectsInit )( CK_SESSION_HANDLE hSession,
         xResult = CKR_ARGUMENTS_BAD;
     }
 
-    if( ( ulCount != 1UL ) && ( ulCount != 2UL ) )
+    if( ( ulCount < 1UL ) || ( ulCount > 2UL ) )
     {
         xResult = CKR_ARGUMENTS_BAD;
         LogError( ( "Failed to initialize find object operation. Find objects "

--- a/source/portable/mbedtls/core_pkcs11_mbedtls.c
+++ b/source/portable/mbedtls/core_pkcs11_mbedtls.c
@@ -763,7 +763,7 @@ static CK_RV prvRsaContextParse( const CK_ATTRIBUTE * pxAttribute,
             break;
 
         default:
-            /* This is the CKA_COEFFICIENT case. The type is ckecked in prvRsaKeyAttParse. */
+            /* This is the CKA_COEFFICIENT case. The type is checked in prvRsaKeyAttParse. */
             lMbedTLSResult = mbedtls_mpi_read_binary( &pxRsaContext->QP, pxAttribute->pValue, pxAttribute->ulValueLen );
             break;
     }

--- a/test/wrapper_utest/core_pkcs11_utest.c
+++ b/test/wrapper_utest/core_pkcs11_utest.c
@@ -179,7 +179,7 @@ static CK_RV prvSetFunctionList( CK_FUNCTION_LIST_PTR_PTR ppxPtr )
 /*!
  * @brief Create a stub for the PKCS #11 function list.
  *
- * Fails on the fourth call in order to create coverage for a nested branch.
+ * Fails on the thrid call in order to create coverage for a nested branch.
  *
  */
 static CK_RV prvSetFunctionList2( CK_FUNCTION_LIST_PTR_PTR ppxPtr )
@@ -205,7 +205,7 @@ static CK_RV prvSetFunctionList2( CK_FUNCTION_LIST_PTR_PTR ppxPtr )
 /*!
  * @brief Create a stub for the PKCS #11 function list.
  *
- * Fails on the fourth call in order to create coverage for a nested branch.
+ * Fails on the third call in order to create coverage for a nested branch.
  *
  */
 static CK_RV prvSetFunctionList3( CK_FUNCTION_LIST_PTR_PTR ppxPtr )
@@ -217,7 +217,7 @@ static CK_RV prvSetFunctionList3( CK_FUNCTION_LIST_PTR_PTR ppxPtr )
 
     if( ulCalls == 3 )
     {
-        xResult = CKR_OK;
+        /* Return CKR_OK but with NULL function list pointer here. */
         *ppxPtr = NULL;
     }
     else

--- a/test/wrapper_utest/core_pkcs11_utest.c
+++ b/test/wrapper_utest/core_pkcs11_utest.c
@@ -179,7 +179,7 @@ static CK_RV prvSetFunctionList( CK_FUNCTION_LIST_PTR_PTR ppxPtr )
 /*!
  * @brief Create a stub for the PKCS #11 function list.
  *
- * Fails on the thrid call in order to create coverage for a nested branch.
+ * Fails on the third call in order to create coverage for a nested branch.
  *
  */
 static CK_RV prvSetFunctionList2( CK_FUNCTION_LIST_PTR_PTR ppxPtr )


### PR DESCRIPTION
<!--- Title -->

Description
-----------
Add more unit test to cover code_pkcs11.c
In this PR:
* Increase line coverage for core_pkcs11_mbedtls.c to 100%
* Update CI line coverage threshold to 100 and branch coverage threshold to 92
* Fix compiler warning in unit test

Test Steps
-----------
N/A

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have tested my changes. No regression in existing tests.
- [x] I have modified and/or added unit-tests to cover the code changes in this Pull Request.

Related Issue
-----------
<!-- If any, please provide issue ID. -->
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
