### PR TITLE
Do not define `__PASTE` macro for Arm-compiler

### DIFF
--- a/source/include/core_pkcs11.h
+++ b/source/include/core_pkcs11.h
@@ -197,8 +197,8 @@
 
 /* Bring in the public header. */
 
-/* Undefine the macro for Keil Compiler to avoid conflict */
-#if defined( __PASTE ) && defined( __CC_ARM )
+/* Undefine the macro for Keil and ARMClang Compilers to avoid conflict */
+#if defined( __PASTE ) && ( defined( __CC_ARM ) || defined( __ARMCC_VERSION ) )
     /* ARM RCVT stdint.h has a duplicate definition with PKCS #11. */
     #undef __PASTE
 #endif


### PR DESCRIPTION
<!--- Title -->

Description
-----------
<!--- Describe your changes in detail. -->
`__PASTE` macro is defined for Arm Compiler in its header files so to avoid conflicts it is undefined as it is already defined by corePkcs11 headers.

The changes are validated with https://github.com/FreeRTOS/iot-reference-arm-corstone3xx

Test Steps
-----------
<!-- Describe the steps to reproduce. -->

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have tested my changes. No regression in existing tests.
- [ ] I have modified and/or added unit-tests to cover the code changes in this Pull Request.

Related Issue
-----------
<!-- If any, please provide issue ID. -->
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
