### PR TITLE
Populate RSA key from mbedtls context to support TLSv1.3

### DIFF
--- a/.github/.cSpellWords.txt
+++ b/.github/.cSpellWords.txt
@@ -37,6 +37,7 @@ DUNITTEST
 DUNITY
 ecdh
 ecjpake
+EABNVYL
 ECKEY
 FAAOCAQE
 Fithb
@@ -51,6 +52,7 @@ HKDF
 isystem
 JITP
 JITR
+JLATES
 Karthikeyan
 lcov
 LPDWORD
@@ -103,11 +105,14 @@ utest
 vect
 Vect
 VECT
+VEIQ
+VQIDAQAB
 Wunused
 xfindobjectwithlabelandclass
 xgetslotlist
 xinitializepkcs
 xtea
 XTEA
+yfiv
 zeroize
 ZEROIZE

--- a/README.md
+++ b/README.md
@@ -192,7 +192,7 @@ locations below:
 |                                                       Location                                                       |
 | :------------------------------------------------------------------------------------------------------------------: |
 | [AWS IoT Device SDK for Embedded C](https://github.com/aws/aws-iot-device-sdk-embedded-C#releases-and-documentation) |
-|      [FreeRTOS.org](https://freertos.org/Documentation/api-ref/corePKCS11/docs/doxygen/output/html/index.html)       |
+|      [FreeRTOS.org](https://freertos.github.io/corePKCS11/v3.6.1/)                                                   |
 
 Note that the latest included version of corePKCS11 may differ across
 repositories.

--- a/docs/doxygen/include/size_table.md
+++ b/docs/doxygen/include/size_table.md
@@ -19,12 +19,12 @@
     </tr>
     <tr>
         <td>core_pkcs11_mbedtls.c</td>
-        <td><center>9.0K</center></td>
-        <td><center>7.4K</center></td>
+        <td><center>9.3K</center></td>
+        <td><center>7.7K</center></td>
     </tr>
     <tr>
         <td><b>Total estimates</b></td>
-        <td><b><center>10.3K</center></b></td>
-        <td><b><center>8.4K</center></b></td>
+        <td><b><center>10.6K</center></b></td>
+        <td><b><center>8.7K</center></b></td>
     </tr>
 </table>

--- a/docs/doxygen/include/size_table.md
+++ b/docs/doxygen/include/size_table.md
@@ -19,12 +19,12 @@
     </tr>
     <tr>
         <td>core_pkcs11_mbedtls.c</td>
-        <td><center>9.3K</center></td>
+        <td><center>9.4K</center></td>
         <td><center>7.7K</center></td>
     </tr>
     <tr>
         <td><b>Total estimates</b></td>
-        <td><b><center>10.6K</center></b></td>
+        <td><b><center>10.7K</center></b></td>
         <td><b><center>8.7K</center></b></td>
     </tr>
 </table>

--- a/source/portable/mbedtls/core_pkcs11_mbedtls.c
+++ b/source/portable/mbedtls/core_pkcs11_mbedtls.c
@@ -3226,6 +3226,7 @@ CK_DECLARE_FUNCTION( CK_RV, C_GetAttributeValue )( CK_SESSION_HANDLE hSession,
     mbedtls_x509_crt xMbedX509Context = { 0 };
     mbedtls_pk_type_t xKeyType;
     const mbedtls_ecp_keypair * pxKeyPair;
+    const mbedtls_rsa_context * pxRsaContext;
     CK_KEY_TYPE xPkcsKeyType = ( CK_KEY_TYPE ) ~0UL;
     CK_OBJECT_CLASS xClass = ~0UL;
     CK_BYTE_PTR pxObjectValue = NULL;
@@ -3534,8 +3535,6 @@ CK_DECLARE_FUNCTION( CK_RV, C_GetAttributeValue )( CK_SESSION_HANDLE hSession,
                 case CKA_EXPONENT_2:
                 case CKA_COEFFICIENT:
                    {
-                       mbedtls_rsa_context * pxRsaContext = ( mbedtls_rsa_context * ) xKeyContext.pk_ctx;
-
                        if( pTemplate[ iAttrib ].pValue == NULL )
                        {
                            pTemplate[ iAttrib ].ulValueLen = sizeof( mbedtls_mpi );
@@ -3544,8 +3543,18 @@ CK_DECLARE_FUNCTION( CK_RV, C_GetAttributeValue )( CK_SESSION_HANDLE hSession,
                        {
                            if( pTemplate[ iAttrib ].ulValueLen == sizeof( mbedtls_mpi ) )
                            {
-                               xResult = prvGetAttributesFromRsaContext( &( pTemplate[ iAttrib ] ),
-                                                                         pxRsaContext );
+                                pxRsaContext = ( mbedtls_rsa_context * ) xKeyContext.pk_ctx;
+
+                                if( pxRsaContext != NULL )
+                                {
+                                    xResult = prvGetAttributesFromRsaContext( &( pTemplate[ iAttrib ] ),
+                                                                              pxRsaContext );
+                                }
+                                else
+                                {
+                                    xResult = CKR_FUNCTION_FAILED;
+                                    pTemplate[ iAttrib ].ulValueLen = CK_UNAVAILABLE_INFORMATION;
+                                }
                            }
                            else
                            {

--- a/source/portable/mbedtls/core_pkcs11_mbedtls.c
+++ b/source/portable/mbedtls/core_pkcs11_mbedtls.c
@@ -3534,36 +3534,35 @@ CK_DECLARE_FUNCTION( CK_RV, C_GetAttributeValue )( CK_SESSION_HANDLE hSession,
                 case CKA_EXPONENT_1:
                 case CKA_EXPONENT_2:
                 case CKA_COEFFICIENT:
-                   {
-                       if( pTemplate[ iAttrib ].pValue == NULL )
-                       {
-                           pTemplate[ iAttrib ].ulValueLen = sizeof( mbedtls_mpi );
-                       }
-                       else
-                       {
-                           if( pTemplate[ iAttrib ].ulValueLen == sizeof( mbedtls_mpi ) )
-                           {
-                                pxRsaContext = ( mbedtls_rsa_context * ) xKeyContext.pk_ctx;
 
-                                if( pxRsaContext != NULL )
-                                {
-                                    xResult = prvGetAttributesFromRsaContext( &( pTemplate[ iAttrib ] ),
-                                                                              pxRsaContext );
-                                }
-                                else
-                                {
-                                    xResult = CKR_FUNCTION_FAILED;
-                                    pTemplate[ iAttrib ].ulValueLen = CK_UNAVAILABLE_INFORMATION;
-                                }
-                           }
-                           else
-                           {
-                               xResult = CKR_BUFFER_TOO_SMALL;
-                           }
-                       }
+                    if( pTemplate[ iAttrib ].pValue == NULL )
+                    {
+                        pTemplate[ iAttrib ].ulValueLen = sizeof( mbedtls_mpi );
+                    }
+                    else
+                    {
+                        if( pTemplate[ iAttrib ].ulValueLen == sizeof( mbedtls_mpi ) )
+                        {
+                            pxRsaContext = ( mbedtls_rsa_context * ) xKeyContext.pk_ctx;
 
-                       break;
-                   }
+                            if( pxRsaContext != NULL )
+                            {
+                                xResult = prvGetAttributesFromRsaContext( &( pTemplate[ iAttrib ] ),
+                                                                          pxRsaContext );
+                            }
+                            else
+                            {
+                                xResult = CKR_FUNCTION_FAILED;
+                                pTemplate[ iAttrib ].ulValueLen = CK_UNAVAILABLE_INFORMATION;
+                            }
+                        }
+                        else
+                        {
+                            xResult = CKR_BUFFER_TOO_SMALL;
+                        }
+                    }
+
+                    break;
 
                 default:
                     LogError( ( "Failed to parse attribute. Received unknown "

--- a/source/portable/mbedtls/core_pkcs11_mbedtls.c
+++ b/source/portable/mbedtls/core_pkcs11_mbedtls.c
@@ -780,6 +780,140 @@ static CK_RV prvRsaContextParse( const CK_ATTRIBUTE * pxAttribute,
 }
 
 /**
+ * @brief Populates attribute values for an RSA key from the mbed TLS context.
+ */
+static CK_RV prvGetAttributesFromRsaContext( CK_ATTRIBUTE * pxAttribute,
+                                             const mbedtls_rsa_context * pxRsaContext )
+{
+    CK_RV xResult = CKR_OK;
+    int32_t lMbedTLSResult = 0;
+    mbedtls_mpi * pxMpi = ( mbedtls_mpi * ) pxAttribute->pValue;
+
+    mbedtls_mpi_init( pxMpi );
+
+    switch( pxAttribute->type )
+    {
+        case ( CKA_MODULUS ):
+
+            lMbedTLSResult = mbedtls_mpi_grow( pxMpi, pxRsaContext->N.n );
+            if( lMbedTLSResult == 0 )
+            {
+                lMbedTLSResult = mbedtls_rsa_export( pxRsaContext,
+                                                     pxMpi,     /* N */
+                                                     NULL,      /* P */
+                                                     NULL,      /* Q */
+                                                     NULL,      /* D */
+                                                     NULL );    /* E */
+            }
+            break;
+
+        case ( CKA_PUBLIC_EXPONENT ):
+
+            lMbedTLSResult = mbedtls_mpi_grow( pxMpi, pxRsaContext->E.n );
+            if( lMbedTLSResult == 0 )
+            {
+                lMbedTLSResult = mbedtls_rsa_export( pxRsaContext,
+                                                     NULL,      /* N */
+                                                     NULL,      /* P */
+                                                     NULL,      /* Q */
+                                                     NULL,      /* D */
+                                                     pxMpi );   /* E */
+            }
+            break;
+
+        case ( CKA_PRIME_1 ):
+
+            lMbedTLSResult = mbedtls_mpi_grow( pxMpi, pxRsaContext->P.n );
+            if( lMbedTLSResult == 0 )
+            {
+                lMbedTLSResult = mbedtls_rsa_export( pxRsaContext,
+                                                     NULL,      /* N */
+                                                     pxMpi,     /* P */
+                                                     NULL,      /* Q */
+                                                     NULL,      /* D */
+                                                     NULL );    /* E */
+            }
+            break;
+
+        case ( CKA_PRIME_2 ):
+
+            lMbedTLSResult = mbedtls_mpi_grow( pxMpi, pxRsaContext->Q.n );
+            if( lMbedTLSResult == 0 )
+            {
+                lMbedTLSResult = mbedtls_rsa_export( pxRsaContext,
+                                                     NULL,      /* N */
+                                                     NULL,      /* P */
+                                                     pxMpi,     /* Q */
+                                                     NULL,      /* D */
+                                                     NULL );    /* E */
+            }
+            break;
+
+        case ( CKA_PRIVATE_EXPONENT ):
+
+            lMbedTLSResult = mbedtls_mpi_grow( pxMpi, pxRsaContext->D.n );
+            if( lMbedTLSResult == 0 )
+            {
+                lMbedTLSResult = mbedtls_rsa_export( pxRsaContext,
+                                                     NULL,      /* N */
+                                                     NULL,      /* P */
+                                                     NULL,      /* Q */
+                                                     pxMpi,     /* D */
+                                                     NULL );    /* E */
+            }
+            break;
+
+        case ( CKA_EXPONENT_1 ):
+
+            lMbedTLSResult = mbedtls_mpi_grow( pxMpi, pxRsaContext->DP.n );
+            if( lMbedTLSResult == 0 )
+            {
+                lMbedTLSResult = mbedtls_rsa_export_crt( pxRsaContext,
+                                                         pxMpi,      /* DP */
+                                                         NULL,       /* DQ */
+                                                         NULL );     /* QP */
+            }
+            break;
+
+        case ( CKA_EXPONENT_2 ):
+
+            lMbedTLSResult = mbedtls_mpi_grow( pxMpi, pxRsaContext->DQ.n );
+            if( lMbedTLSResult == 0 )
+            {
+                lMbedTLSResult = mbedtls_rsa_export_crt( pxRsaContext,
+                                                         NULL,       /* DP */
+                                                         pxMpi,      /* DQ */
+                                                         NULL );     /* QP */
+            }
+            break;
+
+        default:
+
+            /* This is the CKA_COEFFICIENT case. The type is checked in
+             * C_GetAttributeValue. */
+            lMbedTLSResult = mbedtls_mpi_grow( pxMpi, pxRsaContext->QP.n );
+            if( lMbedTLSResult == 0 )
+            {
+                lMbedTLSResult = mbedtls_rsa_export_crt( pxRsaContext,
+                                                         NULL,       /* DP */
+                                                         NULL,       /* DQ */
+                                                         pxMpi );    /* QP */
+            }
+            break;
+    }
+
+    if( lMbedTLSResult != 0 )
+    {
+        LogError( ( "Failed to parse RSA private key attributes: mbed TLS error = %s : %s.",
+                    mbedtlsHighLevelCodeOrDefault( lMbedTLSResult ),
+                    mbedtlsLowLevelCodeOrDefault( lMbedTLSResult ) ) );
+        xResult = CKR_FUNCTION_FAILED;
+    }
+
+    return xResult;
+}
+
+/**
  * @brief Parses attribute values for a RSA Key.
  */
 static CK_RV prvRsaKeyAttParse( const CK_ATTRIBUTE * pxAttribute,
@@ -3294,15 +3428,6 @@ CK_DECLARE_FUNCTION( CK_RV, C_GetAttributeValue )( CK_SESSION_HANDLE hSession,
 
                     break;
 
-                case CKA_PRIVATE_EXPONENT:
-
-                    LogError( ( "Failed to parse attribute. "
-                                "CKA_PRIVATE_EXPONENT is private data." ) );
-                    xResult = CKR_ATTRIBUTE_SENSITIVE;
-                    pTemplate[ iAttrib ].ulValueLen = CK_UNAVAILABLE_INFORMATION;
-
-                    break;
-
                 case CKA_EC_PARAMS:
 
                     if( pTemplate[ iAttrib ].pValue == NULL )
@@ -3382,6 +3507,35 @@ CK_DECLARE_FUNCTION( CK_RV, C_GetAttributeValue )( CK_SESSION_HANDLE hSession,
                         }
                     }
 
+                    break;
+
+                case CKA_MODULUS:
+                case CKA_PUBLIC_EXPONENT:
+                case CKA_PRIME_1:
+                case CKA_PRIME_2:
+                case CKA_PRIVATE_EXPONENT:
+                case CKA_EXPONENT_1:
+                case CKA_EXPONENT_2:
+                case CKA_COEFFICIENT:
+
+                    mbedtls_rsa_context * pxRsaContext = ( mbedtls_rsa_context * ) xKeyContext.pk_ctx;
+
+                    if( pTemplate[ iAttrib ].pValue == NULL )
+                    {
+                        pTemplate[ iAttrib ].ulValueLen = sizeof( mbedtls_mpi );
+                    }
+                    else
+                    {
+                        if( pTemplate[ iAttrib ].ulValueLen == sizeof( mbedtls_mpi ) )
+                        {
+                            xResult = prvGetAttributesFromRsaContext( &( pTemplate[ iAttrib ] ),
+                                                                      pxRsaContext );
+                        }
+                        else
+                        {
+                            xResult = CKR_BUFFER_TOO_SMALL;
+                        }
+                    }
                     break;
 
                 default:

--- a/source/portable/mbedtls/core_pkcs11_mbedtls.c
+++ b/source/portable/mbedtls/core_pkcs11_mbedtls.c
@@ -796,95 +796,109 @@ static CK_RV prvGetAttributesFromRsaContext( CK_ATTRIBUTE * pxAttribute,
         case ( CKA_MODULUS ):
 
             lMbedTLSResult = mbedtls_mpi_grow( pxMpi, pxRsaContext->N.n );
+
             if( lMbedTLSResult == 0 )
             {
                 lMbedTLSResult = mbedtls_rsa_export( pxRsaContext,
-                                                     pxMpi,     /* N */
-                                                     NULL,      /* P */
-                                                     NULL,      /* Q */
-                                                     NULL,      /* D */
-                                                     NULL );    /* E */
+                                                     pxMpi,  /* N */
+                                                     NULL,   /* P */
+                                                     NULL,   /* Q */
+                                                     NULL,   /* D */
+                                                     NULL ); /* E */
             }
+
             break;
 
         case ( CKA_PUBLIC_EXPONENT ):
 
             lMbedTLSResult = mbedtls_mpi_grow( pxMpi, pxRsaContext->E.n );
+
             if( lMbedTLSResult == 0 )
             {
                 lMbedTLSResult = mbedtls_rsa_export( pxRsaContext,
-                                                     NULL,      /* N */
-                                                     NULL,      /* P */
-                                                     NULL,      /* Q */
-                                                     NULL,      /* D */
-                                                     pxMpi );   /* E */
+                                                     NULL,    /* N */
+                                                     NULL,    /* P */
+                                                     NULL,    /* Q */
+                                                     NULL,    /* D */
+                                                     pxMpi ); /* E */
             }
+
             break;
 
         case ( CKA_PRIME_1 ):
 
             lMbedTLSResult = mbedtls_mpi_grow( pxMpi, pxRsaContext->P.n );
+
             if( lMbedTLSResult == 0 )
             {
                 lMbedTLSResult = mbedtls_rsa_export( pxRsaContext,
-                                                     NULL,      /* N */
-                                                     pxMpi,     /* P */
-                                                     NULL,      /* Q */
-                                                     NULL,      /* D */
-                                                     NULL );    /* E */
+                                                     NULL,   /* N */
+                                                     pxMpi,  /* P */
+                                                     NULL,   /* Q */
+                                                     NULL,   /* D */
+                                                     NULL ); /* E */
             }
+
             break;
 
         case ( CKA_PRIME_2 ):
 
             lMbedTLSResult = mbedtls_mpi_grow( pxMpi, pxRsaContext->Q.n );
+
             if( lMbedTLSResult == 0 )
             {
                 lMbedTLSResult = mbedtls_rsa_export( pxRsaContext,
-                                                     NULL,      /* N */
-                                                     NULL,      /* P */
-                                                     pxMpi,     /* Q */
-                                                     NULL,      /* D */
-                                                     NULL );    /* E */
+                                                     NULL,   /* N */
+                                                     NULL,   /* P */
+                                                     pxMpi,  /* Q */
+                                                     NULL,   /* D */
+                                                     NULL ); /* E */
             }
+
             break;
 
         case ( CKA_PRIVATE_EXPONENT ):
 
             lMbedTLSResult = mbedtls_mpi_grow( pxMpi, pxRsaContext->D.n );
+
             if( lMbedTLSResult == 0 )
             {
                 lMbedTLSResult = mbedtls_rsa_export( pxRsaContext,
-                                                     NULL,      /* N */
-                                                     NULL,      /* P */
-                                                     NULL,      /* Q */
-                                                     pxMpi,     /* D */
-                                                     NULL );    /* E */
+                                                     NULL,   /* N */
+                                                     NULL,   /* P */
+                                                     NULL,   /* Q */
+                                                     pxMpi,  /* D */
+                                                     NULL ); /* E */
             }
+
             break;
 
         case ( CKA_EXPONENT_1 ):
 
             lMbedTLSResult = mbedtls_mpi_grow( pxMpi, pxRsaContext->DP.n );
+
             if( lMbedTLSResult == 0 )
             {
                 lMbedTLSResult = mbedtls_rsa_export_crt( pxRsaContext,
-                                                         pxMpi,      /* DP */
-                                                         NULL,       /* DQ */
-                                                         NULL );     /* QP */
+                                                         pxMpi,  /* DP */
+                                                         NULL,   /* DQ */
+                                                         NULL ); /* QP */
             }
+
             break;
 
         case ( CKA_EXPONENT_2 ):
 
             lMbedTLSResult = mbedtls_mpi_grow( pxMpi, pxRsaContext->DQ.n );
+
             if( lMbedTLSResult == 0 )
             {
                 lMbedTLSResult = mbedtls_rsa_export_crt( pxRsaContext,
-                                                         NULL,       /* DP */
-                                                         pxMpi,      /* DQ */
-                                                         NULL );     /* QP */
+                                                         NULL,   /* DP */
+                                                         pxMpi,  /* DQ */
+                                                         NULL ); /* QP */
             }
+
             break;
 
         default:
@@ -892,13 +906,15 @@ static CK_RV prvGetAttributesFromRsaContext( CK_ATTRIBUTE * pxAttribute,
             /* This is the CKA_COEFFICIENT case. The type is checked in
              * C_GetAttributeValue. */
             lMbedTLSResult = mbedtls_mpi_grow( pxMpi, pxRsaContext->QP.n );
+
             if( lMbedTLSResult == 0 )
             {
                 lMbedTLSResult = mbedtls_rsa_export_crt( pxRsaContext,
-                                                         NULL,       /* DP */
-                                                         NULL,       /* DQ */
-                                                         pxMpi );    /* QP */
+                                                         NULL,    /* DP */
+                                                         NULL,    /* DQ */
+                                                         pxMpi ); /* QP */
             }
+
             break;
     }
 
@@ -3517,26 +3533,28 @@ CK_DECLARE_FUNCTION( CK_RV, C_GetAttributeValue )( CK_SESSION_HANDLE hSession,
                 case CKA_EXPONENT_1:
                 case CKA_EXPONENT_2:
                 case CKA_COEFFICIENT:
+                   {
+                       mbedtls_rsa_context * pxRsaContext = ( mbedtls_rsa_context * ) xKeyContext.pk_ctx;
 
-                    mbedtls_rsa_context * pxRsaContext = ( mbedtls_rsa_context * ) xKeyContext.pk_ctx;
+                       if( pTemplate[ iAttrib ].pValue == NULL )
+                       {
+                           pTemplate[ iAttrib ].ulValueLen = sizeof( mbedtls_mpi );
+                       }
+                       else
+                       {
+                           if( pTemplate[ iAttrib ].ulValueLen == sizeof( mbedtls_mpi ) )
+                           {
+                               xResult = prvGetAttributesFromRsaContext( &( pTemplate[ iAttrib ] ),
+                                                                         pxRsaContext );
+                           }
+                           else
+                           {
+                               xResult = CKR_BUFFER_TOO_SMALL;
+                           }
+                       }
 
-                    if( pTemplate[ iAttrib ].pValue == NULL )
-                    {
-                        pTemplate[ iAttrib ].ulValueLen = sizeof( mbedtls_mpi );
-                    }
-                    else
-                    {
-                        if( pTemplate[ iAttrib ].ulValueLen == sizeof( mbedtls_mpi ) )
-                        {
-                            xResult = prvGetAttributesFromRsaContext( &( pTemplate[ iAttrib ] ),
-                                                                      pxRsaContext );
-                        }
-                        else
-                        {
-                            xResult = CKR_BUFFER_TOO_SMALL;
-                        }
-                    }
-                    break;
+                       break;
+                   }
 
                 default:
                     LogError( ( "Failed to parse attribute. Received unknown "

--- a/test/mbedtls_integration/mbedtls_integration_test.c
+++ b/test/mbedtls_integration/mbedtls_integration_test.c
@@ -954,7 +954,7 @@ static void commonValidateCredentialStorageRSA( const char * pPrivateKeyLabel,
     TEST_ASSERT_EQUAL_MEMORY_MESSAGE( expectedCertInDer, template.pValue, template.ulValueLen, "GetAttributeValue returned incorrect data for RSA certificate" );
 
     /* Check that the private key cannot be retrieved. */
-    template.type = CKA_PRIVATE_EXPONENT;
+    template.type = CKA_VALUE;
     template.pValue = keyComponent;
     template.ulValueLen = sizeof( keyComponent );
     result = globalFunctionList->C_GetAttributeValue( globalSession, privateKeyHandle, &template, 1 );

--- a/test/pkcs11_mbedtls_utest/core_pkcs11_mbedtls_utest.c
+++ b/test/pkcs11_mbedtls_utest/core_pkcs11_mbedtls_utest.c
@@ -3212,10 +3212,13 @@ void test_pkcs11_C_GetAttributeValueAttParsing( void )
     CK_BYTE pulBuf[ sizeof( pulKnownBuf ) ] = { 0 };
     CK_BYTE ulPoint[ pkcs11EC_POINT_LENGTH ] = { 0 };
     CK_BYTE ulKnownPoint = 0x04;
+    CK_BYTE_PTR ulKnownPointLoc = &( ulKnownPoint );
     CK_BBOOL xIsPrivate = CK_FALSE;
     CK_OBJECT_CLASS xPrivateKeyClass = { 0 };
     CK_OBJECT_CLASS xKnownPrivateKeyClass = CKO_PRIVATE_KEY;
     CK_ATTRIBUTE xTemplate = { CKA_EC_PARAMS, pulBuf, sizeof( pulBuf ) };
+    mbedtls_ecp_keypair xEcpKeyPair = { 0 };
+    mbedtls_pk_context xKeyContext = { NULL, &xEcpKeyPair };
 
     prvCommonInitStubs( &xSession );
 
@@ -3229,7 +3232,8 @@ void test_pkcs11_C_GetAttributeValueAttParsing( void )
 
 
         /* EC Params Case */
-        mbedtls_pk_init_CMockIgnore();
+        mbedtls_pk_init_ExpectAnyArgs();
+        mbedtls_pk_init_ReturnThruPtr_ctx( &xKeyContext );
         mbedtls_x509_crt_init_CMockIgnore();
         mbedtls_pk_parse_key_IgnoreAndReturn( 0 );
         PKCS11_PAL_GetObjectValueCleanup_CMockIgnore();
@@ -3245,6 +3249,8 @@ void test_pkcs11_C_GetAttributeValueAttParsing( void )
         xTemplate.pValue = NULL;
         xTemplate.ulValueLen = 0;
 
+        mbedtls_pk_init_ExpectAnyArgs();
+        mbedtls_pk_init_ReturnThruPtr_ctx( &xKeyContext );
         xResult = C_GetAttributeValue( xSession, xObject, ( CK_ATTRIBUTE_PTR ) &xTemplate, ulCount );
         TEST_ASSERT_EQUAL( CKR_OK, xResult );
         TEST_ASSERT_EQUAL( pkcs11EC_POINT_LENGTH, xTemplate.ulValueLen );
@@ -3252,6 +3258,8 @@ void test_pkcs11_C_GetAttributeValueAttParsing( void )
         xTemplate.pValue = &ulPoint;
         xTemplate.ulValueLen = sizeof( ulPoint );
 
+        mbedtls_pk_init_ExpectAnyArgs();
+        mbedtls_pk_init_ReturnThruPtr_ctx( &xKeyContext );
         xResult = C_GetAttributeValue( xSession, xObject, ( CK_ATTRIBUTE_PTR ) &xTemplate, ulCount );
         TEST_ASSERT_EQUAL( CKR_OK, xResult );
         TEST_ASSERT_EQUAL( ulKnownPoint, ulPoint[ 0 ] );
@@ -3260,6 +3268,8 @@ void test_pkcs11_C_GetAttributeValueAttParsing( void )
         xTemplate.ulValueLen = sizeof( ulPoint );
 
         mbedtls_ecp_tls_write_point_IgnoreAndReturn( MBEDTLS_ERR_ECP_BUFFER_TOO_SMALL );
+        mbedtls_pk_init_ExpectAnyArgs();
+        mbedtls_pk_init_ReturnThruPtr_ctx( &xKeyContext );
         xResult = C_GetAttributeValue( xSession, xObject, ( CK_ATTRIBUTE_PTR ) &xTemplate, ulCount );
         TEST_ASSERT_EQUAL( CKR_BUFFER_TOO_SMALL, xResult );
         TEST_ASSERT_EQUAL( CK_UNAVAILABLE_INFORMATION, xTemplate.ulValueLen );
@@ -3268,6 +3278,8 @@ void test_pkcs11_C_GetAttributeValueAttParsing( void )
         xTemplate.pValue = &ulPoint;
         xTemplate.ulValueLen = sizeof( ulPoint );
 
+        mbedtls_pk_init_ExpectAnyArgs();
+        mbedtls_pk_init_ReturnThruPtr_ctx( &xKeyContext );
         xResult = C_GetAttributeValue( xSession, xObject, ( CK_ATTRIBUTE_PTR ) &xTemplate, ulCount );
         TEST_ASSERT_EQUAL( CKR_FUNCTION_FAILED, xResult );
         TEST_ASSERT_EQUAL( CK_UNAVAILABLE_INFORMATION, xTemplate.ulValueLen );
@@ -3277,6 +3289,8 @@ void test_pkcs11_C_GetAttributeValueAttParsing( void )
         /* Unknown attribute. */
         xTemplate.type = CKA_SUBPRIME;
 
+        mbedtls_pk_init_ExpectAnyArgs();
+        mbedtls_pk_init_ReturnThruPtr_ctx( &xKeyContext );
         xResult = C_GetAttributeValue( xSession, xObject, ( CK_ATTRIBUTE_PTR ) &xTemplate, ulCount );
         TEST_ASSERT_EQUAL( CKR_ATTRIBUTE_TYPE_INVALID, xResult );
         TEST_ASSERT_EQUAL( CK_UNAVAILABLE_INFORMATION, xTemplate.ulValueLen );
@@ -3287,6 +3301,8 @@ void test_pkcs11_C_GetAttributeValueAttParsing( void )
         xTemplate.ulValueLen = 0;
 
         mbedtls_pk_parse_key_IgnoreAndReturn( 0 );
+        mbedtls_pk_init_ExpectAnyArgs();
+        mbedtls_pk_init_ReturnThruPtr_ctx( &xKeyContext );
         xResult = C_GetAttributeValue( xSession, xObject, ( CK_ATTRIBUTE_PTR ) &xTemplate, ulCount );
         TEST_ASSERT_EQUAL( CKR_OK, xResult );
         TEST_ASSERT_EQUAL( NULL, xTemplate.pValue );
@@ -3294,6 +3310,8 @@ void test_pkcs11_C_GetAttributeValueAttParsing( void )
 
         xTemplate.pValue = &xPrivateKeyClass;
 
+        mbedtls_pk_init_ExpectAnyArgs();
+        mbedtls_pk_init_ReturnThruPtr_ctx( &xKeyContext );
         xResult = C_GetAttributeValue( xSession, xObject, ( CK_ATTRIBUTE_PTR ) &xTemplate, ulCount );
         TEST_ASSERT_EQUAL( CKR_OK, xResult );
         TEST_ASSERT_EQUAL( sizeof( xPrivateKeyClass ), xTemplate.ulValueLen );
@@ -3307,6 +3325,8 @@ void test_pkcs11_C_GetAttributeValueAttParsing( void )
         PKCS11_PAL_GetObjectValue_ExpectAnyArgsAndReturn( CKR_OK );
         PKCS11_PAL_GetObjectValue_ReturnThruPtr_pIsPrivate( &xIsPrivate );
         PKCS11_PAL_GetObjectValue_ReturnThruPtr_pulDataSize( &ulLength );
+        mbedtls_pk_init_ExpectAnyArgs();
+        mbedtls_pk_init_ReturnThruPtr_ctx( &xKeyContext );
         mbedtls_pk_parse_key_IgnoreAndReturn( 1 );
         mbedtls_pk_parse_public_key_ExpectAnyArgsAndReturn( 0 );
         xResult = C_GetAttributeValue( xSession, xObjectPub, ( CK_ATTRIBUTE_PTR ) &xTemplate, ulCount );
@@ -3321,6 +3341,8 @@ void test_pkcs11_C_GetAttributeValueAttParsing( void )
         PKCS11_PAL_GetObjectValue_ReturnThruPtr_pIsPrivate( &xIsPrivate );
         PKCS11_PAL_GetObjectValue_ReturnThruPtr_pulDataSize( &ulLength );
         mbedtls_pk_parse_key_IgnoreAndReturn( 0 );
+        mbedtls_pk_init_ExpectAnyArgs();
+        mbedtls_pk_init_ReturnThruPtr_ctx( &xKeyContext );
         xResult = C_GetAttributeValue( xSession, xObjectPub, ( CK_ATTRIBUTE_PTR ) &xTemplate, ulCount );
         TEST_ASSERT_EQUAL( CKR_BUFFER_TOO_SMALL, xResult );
         TEST_ASSERT_EQUAL( CK_UNAVAILABLE_INFORMATION, xTemplate.ulValueLen );
@@ -3331,6 +3353,9 @@ void test_pkcs11_C_GetAttributeValueAttParsing( void )
 
         PKCS11_PAL_GetObjectValue_ExpectAnyArgsAndReturn( CKR_OK );
         PKCS11_PAL_GetObjectValue_ReturnThruPtr_pIsPrivate( &xIsPrivate );
+        PKCS11_PAL_GetObjectValue_ReturnThruPtr_ppucData( &ulKnownPointLoc );
+        mbedtls_pk_init_ExpectAnyArgs();
+        mbedtls_pk_init_ReturnThruPtr_ctx( &xKeyContext );
         xResult = C_GetAttributeValue( xSession, xObjectPub, ( CK_ATTRIBUTE_PTR ) &xTemplate, ulCount );
         TEST_ASSERT_EQUAL( CKR_OK, xResult );
         TEST_ASSERT_EQUAL( 1, xTemplate.ulValueLen );
@@ -3373,6 +3398,8 @@ void test_pkcs11_C_GetAttributeValueMultipleAttParsing( void )
     CK_ULONG ulCount = 2;
     CK_BYTE ulPoint[ pkcs11EC_POINT_LENGTH ] = { 0 };
     CK_ATTRIBUTE xTemplates[ 2 ] = { 0 };
+    mbedtls_ecp_keypair xEcpKeyPair = { 0 };
+    mbedtls_pk_context xKeyContext = { NULL, &xEcpKeyPair };
 
     prvCommonInitStubs( &xSession );
 
@@ -3381,7 +3408,8 @@ void test_pkcs11_C_GetAttributeValueMultipleAttParsing( void )
         xResult = prvCreateEcPriv( &xSession, &xObject );
         TEST_ASSERT_EQUAL( CKR_OK, xResult );
 
-        mbedtls_pk_init_CMockIgnore();
+        mbedtls_pk_init_ExpectAnyArgs();
+        mbedtls_pk_init_ReturnThruPtr_ctx( &xKeyContext );
         mbedtls_x509_crt_init_CMockIgnore();
         PKCS11_PAL_GetObjectValueCleanup_CMockIgnore();
         mbedtls_pk_free_CMockIgnore();
@@ -3414,6 +3442,9 @@ void test_pkcs11_C_GetAttributeValueMultipleAttParsing( void )
         xTemplates[ 1 ].type = CKA_EC_POINT;
         xTemplates[ 1 ].pValue = NULL;
         xTemplates[ 1 ].ulValueLen = 0;
+
+        mbedtls_pk_init_ExpectAnyArgs();
+        mbedtls_pk_init_ReturnThruPtr_ctx( &xKeyContext );
         xResult = C_GetAttributeValue( xSession, xObject, ( CK_ATTRIBUTE_PTR ) &xTemplates, ulCount );
 
         /* CKR_ATTRIBUTE_TYPE_INVALID should be returned. */
@@ -3432,6 +3463,8 @@ void test_pkcs11_C_GetAttributeValueMultipleAttParsing( void )
         xTemplates[ 1 ].ulValueLen = 0;
 
         /* CKR_BUFFER_TOO_SMALL should be returned. */
+        mbedtls_pk_init_ExpectAnyArgs();
+        mbedtls_pk_init_ReturnThruPtr_ctx( &xKeyContext );
         xResult = C_GetAttributeValue( xSession, xObject, ( CK_ATTRIBUTE_PTR ) &xTemplates, ulCount );
         TEST_ASSERT_EQUAL( CKR_BUFFER_TOO_SMALL, xResult );
         TEST_ASSERT_EQUAL( CK_UNAVAILABLE_INFORMATION, xTemplates[ 0 ].ulValueLen );
@@ -3449,13 +3482,14 @@ void test_pkcs11_C_GetAttributeValueMultipleAttParsing( void )
         xTemplates[ 1 ].ulValueLen = 0;
 
         /* CKR_BUFFER_TOO_SMALL should be returned. */
+        mbedtls_pk_init_ExpectAnyArgs();
+        mbedtls_pk_init_ReturnThruPtr_ctx( &xKeyContext );
         xResult = C_GetAttributeValue( xSession, xObject, ( CK_ATTRIBUTE_PTR ) &xTemplates, ulCount );
         TEST_ASSERT_EQUAL( CKR_BUFFER_TOO_SMALL, xResult );
         TEST_ASSERT_EQUAL( pkcs11EC_POINT_LENGTH, xTemplates[ 0 ].ulValueLen );
         TEST_ASSERT_EQUAL( CK_UNAVAILABLE_INFORMATION, xTemplates[ 1 ].ulValueLen );
 
         /* CKR_ATTRIBUTE_SENSITIVE should be returned when getting CKA_VALUE type. */
-        mbedtls_pk_parse_key_ExpectAnyArgsAndReturn( 0 );
         xTemplates[ 0 ].type = CKA_VALUE;
         xTemplates[ 0 ].pValue = NULL;
         xTemplates[ 0 ].ulValueLen = 0;
@@ -3466,6 +3500,9 @@ void test_pkcs11_C_GetAttributeValueMultipleAttParsing( void )
         xTemplates[ 1 ].ulValueLen = 0;
 
         /* CKA_PRIVATE_EXPONENT should be returned. */
+        mbedtls_pk_init_ExpectAnyArgs();
+        mbedtls_pk_init_ReturnThruPtr_ctx( &xKeyContext );
+        mbedtls_pk_parse_key_ExpectAnyArgsAndReturn( 0 );
         xResult = C_GetAttributeValue( xSession, xObject, ( CK_ATTRIBUTE_PTR ) &xTemplates, ulCount );
         TEST_ASSERT_EQUAL( CKR_ATTRIBUTE_SENSITIVE, xResult );
         TEST_ASSERT_EQUAL( CK_UNAVAILABLE_INFORMATION, xTemplates[ 0 ].ulValueLen );
@@ -3477,20 +3514,20 @@ void test_pkcs11_C_GetAttributeValueMultipleAttParsing( void )
         xTemplates[ 0 ].ulValueLen = 0;
 
         /* CKR_ATTRIBUTE_SENSITIVE should be returned when getting CKA_VALUE type. */
-        mbedtls_pk_parse_key_ExpectAnyArgsAndReturn( 0 );
         xTemplates[ 1 ].type = CKA_VALUE;
         xTemplates[ 1 ].pValue = NULL;
         xTemplates[ 1 ].ulValueLen = 0;
 
         /* CKA_PRIVATE_EXPONENT should be returned. */
+        mbedtls_pk_init_ExpectAnyArgs();
+        mbedtls_pk_init_ReturnThruPtr_ctx( &xKeyContext );
+        mbedtls_pk_parse_key_ExpectAnyArgsAndReturn( 0 );
         xResult = C_GetAttributeValue( xSession, xObject, ( CK_ATTRIBUTE_PTR ) &xTemplates, ulCount );
         TEST_ASSERT_EQUAL( CKR_ATTRIBUTE_SENSITIVE, xResult );
         TEST_ASSERT_EQUAL( pkcs11EC_POINT_LENGTH, xTemplates[ 0 ].ulValueLen );
         TEST_ASSERT_EQUAL( CK_UNAVAILABLE_INFORMATION, xTemplates[ 1 ].ulValueLen );
 
         /* CKR_FUNCTION_FAILED should be returned when mbedtls_ecp_tls_write_point returns -1.  */
-        mbedtls_pk_parse_key_IgnoreAndReturn( 0 );
-        mbedtls_ecp_tls_write_point_IgnoreAndReturn( -1 );
         xTemplates[ 0 ].type = CKA_EC_POINT;
         xTemplates[ 0 ].pValue = &ulPoint;
         xTemplates[ 0 ].ulValueLen = sizeof( ulPoint );
@@ -3501,6 +3538,10 @@ void test_pkcs11_C_GetAttributeValueMultipleAttParsing( void )
         xTemplates[ 1 ].ulValueLen = 0;
 
         /* CKR_FUNCTION_FAILED should be returned. */
+        mbedtls_pk_init_ExpectAnyArgs();
+        mbedtls_pk_init_ReturnThruPtr_ctx( &xKeyContext );
+        mbedtls_pk_parse_key_IgnoreAndReturn( 0 );
+        mbedtls_ecp_tls_write_point_IgnoreAndReturn( -1 );
         xResult = C_GetAttributeValue( xSession, xObject, ( CK_ATTRIBUTE_PTR ) &xTemplates, ulCount );
         TEST_ASSERT_EQUAL( CKR_FUNCTION_FAILED, xResult );
         TEST_ASSERT_EQUAL( CK_UNAVAILABLE_INFORMATION, xTemplates[ 0 ].ulValueLen );
@@ -3513,13 +3554,15 @@ void test_pkcs11_C_GetAttributeValueMultipleAttParsing( void )
         xTemplates[ 0 ].ulValueLen = 0;
 
         /* CKR_FUNCTION_FAILED should be returned when mbedtls_ecp_tls_write_point returns -1.  */
-        mbedtls_pk_parse_key_IgnoreAndReturn( 0 );
-        mbedtls_ecp_tls_write_point_IgnoreAndReturn( -1 );
         xTemplates[ 1 ].type = CKA_EC_POINT;
         xTemplates[ 1 ].pValue = &ulPoint;
         xTemplates[ 1 ].ulValueLen = sizeof( ulPoint );
 
         /* CKR_FUNCTION_FAILED should be returned. */
+        mbedtls_pk_init_ExpectAnyArgs();
+        mbedtls_pk_init_ReturnThruPtr_ctx( &xKeyContext );
+        mbedtls_pk_parse_key_IgnoreAndReturn( 0 );
+        mbedtls_ecp_tls_write_point_IgnoreAndReturn( -1 );
         xResult = C_GetAttributeValue( xSession, xObject, ( CK_ATTRIBUTE_PTR ) &xTemplates, ulCount );
         TEST_ASSERT_EQUAL( CKR_FUNCTION_FAILED, xResult );
         TEST_ASSERT_EQUAL( pkcs11EC_POINT_LENGTH, xTemplates[ 0 ].ulValueLen );
@@ -3531,21 +3574,21 @@ void test_pkcs11_C_GetAttributeValueMultipleAttParsing( void )
         xTemplates[ 0 ].ulValueLen = 0;
 
         /* CKR_FUNCTION_FAILED should be returned when mbedtls_ecp_tls_write_point returns -1.  */
-        mbedtls_pk_parse_key_IgnoreAndReturn( 0 );
-        mbedtls_ecp_tls_write_point_IgnoreAndReturn( -1 );
         xTemplates[ 1 ].type = CKA_EC_POINT;
         xTemplates[ 1 ].pValue = &ulPoint;
         xTemplates[ 1 ].ulValueLen = sizeof( ulPoint );
 
         /* CKR_FUNCTION_FAILED should be returned. */
+        mbedtls_pk_init_ExpectAnyArgs();
+        mbedtls_pk_init_ReturnThruPtr_ctx( &xKeyContext );
+        mbedtls_pk_parse_key_IgnoreAndReturn( 0 );
+        mbedtls_ecp_tls_write_point_IgnoreAndReturn( -1 );
         xResult = C_GetAttributeValue( xSession, xObject, ( CK_ATTRIBUTE_PTR ) &xTemplates, ulCount );
         TEST_ASSERT_EQUAL( CKR_FUNCTION_FAILED, xResult );
         TEST_ASSERT_EQUAL( CK_UNAVAILABLE_INFORMATION, xTemplates[ 0 ].ulValueLen );
         TEST_ASSERT_EQUAL( CK_UNAVAILABLE_INFORMATION, xTemplates[ 1 ].ulValueLen );
 
         /* CKR_FUNCTION_FAILED should be returned when mbedtls_ecp_tls_write_point returns -1.  */
-        mbedtls_pk_parse_key_IgnoreAndReturn( 0 );
-        mbedtls_ecp_tls_write_point_IgnoreAndReturn( -1 );
         xTemplates[ 0 ].type = CKA_EC_POINT;
         xTemplates[ 0 ].pValue = &ulPoint;
         xTemplates[ 0 ].ulValueLen = sizeof( ulPoint );
@@ -3556,6 +3599,10 @@ void test_pkcs11_C_GetAttributeValueMultipleAttParsing( void )
         xTemplates[ 1 ].ulValueLen = 0;
 
         /* CKR_FUNCTION_FAILED should be returned. */
+        mbedtls_pk_init_ExpectAnyArgs();
+        mbedtls_pk_init_ReturnThruPtr_ctx( &xKeyContext );
+        mbedtls_pk_parse_key_IgnoreAndReturn( 0 );
+        mbedtls_ecp_tls_write_point_IgnoreAndReturn( -1 );
         xResult = C_GetAttributeValue( xSession, xObject, ( CK_ATTRIBUTE_PTR ) &xTemplates, ulCount );
         TEST_ASSERT_EQUAL( CKR_FUNCTION_FAILED, xResult );
         TEST_ASSERT_EQUAL( CK_UNAVAILABLE_INFORMATION, xTemplates[ 0 ].ulValueLen );
@@ -3579,18 +3626,21 @@ void test_pkcs11_C_GetAttributeValueValidRsaContext( void )
     CK_OBJECT_HANDLE xObject = 0;
     CK_ULONG ulCount = 1;
     CK_ATTRIBUTE xTemplates[ 1 ] = { 0 };
-    mbedtls_pk_context xKeyContext = { NULL, &xResult };
-    CK_BYTE ulPoint[ pkcs11EC_POINT_LENGTH ] = { 0 };
+    mbedtls_rsa_context xRsaContext = { 0 };
+    mbedtls_pk_context xKeyContext = { NULL, &xRsaContext };
+    mbedtls_mpi xMpi;
 
     prvCommonInitStubs( &xSession );
 
     if( TEST_PROTECT() )
     {
-        xResult = prvCreateEcPriv( &xSession, &xObject );
+        xResult = prvCreateRsaPriv( &xSession, &xObject );
         TEST_ASSERT_EQUAL( CKR_OK, xResult );
 
         mbedtls_mpi_init_Ignore();
         mbedtls_x509_crt_init_CMockIgnore();
+        mbedtls_pk_parse_key_IgnoreAndReturn( 0 );
+        PKCS11_PAL_GetObjectValue_IgnoreAndReturn( CKR_OK );
         PKCS11_PAL_GetObjectValueCleanup_CMockIgnore();
         mbedtls_pk_free_CMockIgnore();
         mbedtls_x509_crt_free_CMockIgnore();
@@ -3598,8 +3648,8 @@ void test_pkcs11_C_GetAttributeValueValidRsaContext( void )
         /* CKA_MODULUS case */
         /* Failure path */
         xTemplates[ 0 ].type = CKA_MODULUS;
-        xTemplates[ 0 ].pValue = &ulPoint;
-        xTemplates[ 0 ].ulValueLen = ( sizeof( mbedtls_mpi ) );
+        xTemplates[ 0 ].pValue = &( xMpi );
+        xTemplates[ 0 ].ulValueLen = sizeof( mbedtls_mpi );
 
         mbedtls_pk_init_ExpectAnyArgs();
         mbedtls_pk_init_ReturnThruPtr_ctx( &xKeyContext );
@@ -3611,8 +3661,8 @@ void test_pkcs11_C_GetAttributeValueValidRsaContext( void )
         /* CKA_MODULUS case */
         /* Success path */
         xTemplates[ 0 ].type = CKA_MODULUS;
-        xTemplates[ 0 ].pValue = &ulPoint;
-        xTemplates[ 0 ].ulValueLen = ( sizeof( mbedtls_mpi ) );
+        xTemplates[ 0 ].pValue = &( xMpi );
+        xTemplates[ 0 ].ulValueLen = sizeof( mbedtls_mpi );
 
         mbedtls_pk_init_ExpectAnyArgs();
         mbedtls_pk_init_ReturnThruPtr_ctx( &xKeyContext );
@@ -3627,8 +3677,8 @@ void test_pkcs11_C_GetAttributeValueValidRsaContext( void )
         /* CKA_PUBLIC_EXPONENT case */
         /* Failure path */
         xTemplates[ 0 ].type = CKA_PUBLIC_EXPONENT;
-        xTemplates[ 0 ].pValue = &ulPoint;
-        xTemplates[ 0 ].ulValueLen = ( sizeof( mbedtls_mpi ) );
+        xTemplates[ 0 ].pValue = &( xMpi );
+        xTemplates[ 0 ].ulValueLen = sizeof( mbedtls_mpi );
 
         mbedtls_pk_init_ExpectAnyArgs();
         mbedtls_pk_init_ReturnThruPtr_ctx( &xKeyContext );
@@ -3640,8 +3690,8 @@ void test_pkcs11_C_GetAttributeValueValidRsaContext( void )
         /* CKA_PUBLIC_EXPONENT case */
         /* Success path */
         xTemplates[ 0 ].type = CKA_PUBLIC_EXPONENT;
-        xTemplates[ 0 ].pValue = &ulPoint;
-        xTemplates[ 0 ].ulValueLen = ( sizeof( mbedtls_mpi ) );
+        xTemplates[ 0 ].pValue = &( xMpi );
+        xTemplates[ 0 ].ulValueLen = sizeof( mbedtls_mpi );
 
         mbedtls_pk_init_ExpectAnyArgs();
         mbedtls_pk_init_ReturnThruPtr_ctx( &xKeyContext );
@@ -3656,8 +3706,8 @@ void test_pkcs11_C_GetAttributeValueValidRsaContext( void )
         /* CKA_PRIME_1 case */
         /* Failure path */
         xTemplates[ 0 ].type = CKA_PRIME_1;
-        xTemplates[ 0 ].pValue = &ulPoint;
-        xTemplates[ 0 ].ulValueLen = ( sizeof( mbedtls_mpi ) );
+        xTemplates[ 0 ].pValue = &( xMpi );
+        xTemplates[ 0 ].ulValueLen = sizeof( mbedtls_mpi );
 
         mbedtls_pk_init_ExpectAnyArgs();
         mbedtls_pk_init_ReturnThruPtr_ctx( &xKeyContext );
@@ -3669,8 +3719,8 @@ void test_pkcs11_C_GetAttributeValueValidRsaContext( void )
         /* CKA_PRIME_1 case */
         /* Success path */
         xTemplates[ 0 ].type = CKA_PRIME_1;
-        xTemplates[ 0 ].pValue = &ulPoint;
-        xTemplates[ 0 ].ulValueLen = ( sizeof( mbedtls_mpi ) );
+        xTemplates[ 0 ].pValue = &( xMpi );
+        xTemplates[ 0 ].ulValueLen = sizeof( mbedtls_mpi );
 
         mbedtls_pk_init_ExpectAnyArgs();
         mbedtls_pk_init_ReturnThruPtr_ctx( &xKeyContext );
@@ -3685,8 +3735,8 @@ void test_pkcs11_C_GetAttributeValueValidRsaContext( void )
         /* CKA_PRIME_2 case */
         /* Failure path */
         xTemplates[ 0 ].type = CKA_PRIME_2;
-        xTemplates[ 0 ].pValue = &ulPoint;
-        xTemplates[ 0 ].ulValueLen = ( sizeof( mbedtls_mpi ) );
+        xTemplates[ 0 ].pValue = &( xMpi );
+        xTemplates[ 0 ].ulValueLen = sizeof( mbedtls_mpi );
 
         mbedtls_pk_init_ExpectAnyArgs();
         mbedtls_pk_init_ReturnThruPtr_ctx( &xKeyContext );
@@ -3698,8 +3748,8 @@ void test_pkcs11_C_GetAttributeValueValidRsaContext( void )
         /* CKA_PRIME_2 case */
         /* Success path */
         xTemplates[ 0 ].type = CKA_PRIME_2;
-        xTemplates[ 0 ].pValue = &ulPoint;
-        xTemplates[ 0 ].ulValueLen = ( sizeof( mbedtls_mpi ) );
+        xTemplates[ 0 ].pValue = &( xMpi );
+        xTemplates[ 0 ].ulValueLen = sizeof( mbedtls_mpi );
 
         mbedtls_pk_init_ExpectAnyArgs();
         mbedtls_pk_init_ReturnThruPtr_ctx( &xKeyContext );
@@ -3714,8 +3764,8 @@ void test_pkcs11_C_GetAttributeValueValidRsaContext( void )
         /* CKA_PRIVATE_EXPONENT case */
         /* Failure path */
         xTemplates[ 0 ].type = CKA_PRIVATE_EXPONENT;
-        xTemplates[ 0 ].pValue = &ulPoint;
-        xTemplates[ 0 ].ulValueLen = ( sizeof( mbedtls_mpi ) );
+        xTemplates[ 0 ].pValue = &( xMpi );
+        xTemplates[ 0 ].ulValueLen = sizeof( mbedtls_mpi );
 
         mbedtls_pk_init_ExpectAnyArgs();
         mbedtls_pk_init_ReturnThruPtr_ctx( &xKeyContext );
@@ -3727,8 +3777,8 @@ void test_pkcs11_C_GetAttributeValueValidRsaContext( void )
         /* CKA_PRIVATE_EXPONENT case */
         /* Success path */
         xTemplates[ 0 ].type = CKA_PRIVATE_EXPONENT;
-        xTemplates[ 0 ].pValue = &ulPoint;
-        xTemplates[ 0 ].ulValueLen = ( sizeof( mbedtls_mpi ) );
+        xTemplates[ 0 ].pValue = &( xMpi );
+        xTemplates[ 0 ].ulValueLen = sizeof( mbedtls_mpi );
 
         mbedtls_pk_init_ExpectAnyArgs();
         mbedtls_pk_init_ReturnThruPtr_ctx( &xKeyContext );
@@ -3743,8 +3793,8 @@ void test_pkcs11_C_GetAttributeValueValidRsaContext( void )
         /* CKA_PRIVATE_EXPONENT case */
         /* Failure path */
         xTemplates[ 0 ].type = CKA_PRIVATE_EXPONENT;
-        xTemplates[ 0 ].pValue = &ulPoint;
-        xTemplates[ 0 ].ulValueLen = ( sizeof( mbedtls_mpi ) );
+        xTemplates[ 0 ].pValue = &( xMpi );
+        xTemplates[ 0 ].ulValueLen = sizeof( mbedtls_mpi );
 
         mbedtls_pk_init_ExpectAnyArgs();
         mbedtls_pk_init_ReturnThruPtr_ctx( &xKeyContext );
@@ -3756,8 +3806,8 @@ void test_pkcs11_C_GetAttributeValueValidRsaContext( void )
         /* CKA_PRIVATE_EXPONENT case */
         /* Success path */
         xTemplates[ 0 ].type = CKA_PRIVATE_EXPONENT;
-        xTemplates[ 0 ].pValue = &ulPoint;
-        xTemplates[ 0 ].ulValueLen = ( sizeof( mbedtls_mpi ) );
+        xTemplates[ 0 ].pValue = &( xMpi );
+        xTemplates[ 0 ].ulValueLen = sizeof( mbedtls_mpi );
 
         mbedtls_pk_init_ExpectAnyArgs();
         mbedtls_pk_init_ReturnThruPtr_ctx( &xKeyContext );
@@ -3772,8 +3822,8 @@ void test_pkcs11_C_GetAttributeValueValidRsaContext( void )
         /* CKA_EXPONENT_1 case */
         /* Failure path */
         xTemplates[ 0 ].type = CKA_EXPONENT_1;
-        xTemplates[ 0 ].pValue = &ulPoint;
-        xTemplates[ 0 ].ulValueLen = ( sizeof( mbedtls_mpi ) );
+        xTemplates[ 0 ].pValue = &( xMpi );
+        xTemplates[ 0 ].ulValueLen = sizeof( mbedtls_mpi );
 
         mbedtls_pk_init_ExpectAnyArgs();
         mbedtls_pk_init_ReturnThruPtr_ctx( &xKeyContext );
@@ -3785,8 +3835,8 @@ void test_pkcs11_C_GetAttributeValueValidRsaContext( void )
         /* CKA_EXPONENT_1 case */
         /* Success path */
         xTemplates[ 0 ].type = CKA_EXPONENT_1;
-        xTemplates[ 0 ].pValue = &ulPoint;
-        xTemplates[ 0 ].ulValueLen = ( sizeof( mbedtls_mpi ) );
+        xTemplates[ 0 ].pValue = &( xMpi );
+        xTemplates[ 0 ].ulValueLen = sizeof( mbedtls_mpi );
 
         mbedtls_pk_init_ExpectAnyArgs();
         mbedtls_pk_init_ReturnThruPtr_ctx( &xKeyContext );
@@ -3801,8 +3851,8 @@ void test_pkcs11_C_GetAttributeValueValidRsaContext( void )
         /* CKA_EXPONENT_2 case */
         /* Failure path */
         xTemplates[ 0 ].type = CKA_EXPONENT_2;
-        xTemplates[ 0 ].pValue = &ulPoint;
-        xTemplates[ 0 ].ulValueLen = ( sizeof( mbedtls_mpi ) );
+        xTemplates[ 0 ].pValue = &( xMpi );
+        xTemplates[ 0 ].ulValueLen = sizeof( mbedtls_mpi );
 
         mbedtls_pk_init_ExpectAnyArgs();
         mbedtls_pk_init_ReturnThruPtr_ctx( &xKeyContext );
@@ -3814,8 +3864,8 @@ void test_pkcs11_C_GetAttributeValueValidRsaContext( void )
         /* CKA_EXPONENT_2 case */
         /* Success path */
         xTemplates[ 0 ].type = CKA_EXPONENT_2;
-        xTemplates[ 0 ].pValue = &ulPoint;
-        xTemplates[ 0 ].ulValueLen = ( sizeof( mbedtls_mpi ) );
+        xTemplates[ 0 ].pValue = &( xMpi );
+        xTemplates[ 0 ].ulValueLen = sizeof( mbedtls_mpi );
 
         mbedtls_pk_init_ExpectAnyArgs();
         mbedtls_pk_init_ReturnThruPtr_ctx( &xKeyContext );
@@ -3830,8 +3880,8 @@ void test_pkcs11_C_GetAttributeValueValidRsaContext( void )
         /* CKA_COEFFICIENT case */
         /* Failure path */
         xTemplates[ 0 ].type = CKA_COEFFICIENT;
-        xTemplates[ 0 ].pValue = &ulPoint;
-        xTemplates[ 0 ].ulValueLen = ( sizeof( mbedtls_mpi ) );
+        xTemplates[ 0 ].pValue = &( xMpi );
+        xTemplates[ 0 ].ulValueLen = sizeof( mbedtls_mpi );
 
         mbedtls_pk_init_ExpectAnyArgs();
         mbedtls_pk_init_ReturnThruPtr_ctx( &xKeyContext );
@@ -3843,8 +3893,8 @@ void test_pkcs11_C_GetAttributeValueValidRsaContext( void )
         /* CKA_COEFFICIENT case */
         /* Success path */
         xTemplates[ 0 ].type = CKA_COEFFICIENT;
-        xTemplates[ 0 ].pValue = &ulPoint;
-        xTemplates[ 0 ].ulValueLen = ( sizeof( mbedtls_mpi ) );
+        xTemplates[ 0 ].pValue = &( xMpi );
+        xTemplates[ 0 ].ulValueLen = sizeof( mbedtls_mpi );
 
         mbedtls_pk_init_ExpectAnyArgs();
         mbedtls_pk_init_ReturnThruPtr_ctx( &xKeyContext );
@@ -3920,7 +3970,6 @@ void test_pkcs11_C_GetAttributeValueModulusBadPath( void )
     CK_OBJECT_HANDLE xObject = 0;
     CK_ULONG ulCount = 1;
     CK_ATTRIBUTE xTemplates[ 1 ] = { 0 };
-    mbedtls_pk_context xKeyContext = { NULL, NULL };
     CK_BYTE ulPoint[ pkcs11EC_POINT_LENGTH ] = { 0 };
 
     prvCommonInitStubs( &xSession );

--- a/test/pkcs11_mbedtls_utest/core_pkcs11_mbedtls_utest.c
+++ b/test/pkcs11_mbedtls_utest/core_pkcs11_mbedtls_utest.c
@@ -3599,7 +3599,7 @@ void test_pkcs11_C_GetAttributeValueValidRsaContext( void )
         /* Failure path */
         xTemplates[ 0 ].type = CKA_MODULUS;
         xTemplates[ 0 ].pValue = &ulPoint;
-        xTemplates[ 0 ].ulValueLen = ( sizeof( mbedtls_mpi ) );        
+        xTemplates[ 0 ].ulValueLen = ( sizeof( mbedtls_mpi ) );
 
         mbedtls_pk_init_ExpectAnyArgs();
         mbedtls_pk_init_ReturnThruPtr_ctx( &xKeyContext );
@@ -3613,7 +3613,7 @@ void test_pkcs11_C_GetAttributeValueValidRsaContext( void )
         xTemplates[ 0 ].type = CKA_MODULUS;
         xTemplates[ 0 ].pValue = &ulPoint;
         xTemplates[ 0 ].ulValueLen = ( sizeof( mbedtls_mpi ) );
-        
+
         mbedtls_pk_init_ExpectAnyArgs();
         mbedtls_pk_init_ReturnThruPtr_ctx( &xKeyContext );
         mbedtls_mpi_grow_ExpectAnyArgsAndReturn( 0 );
@@ -3622,13 +3622,13 @@ void test_pkcs11_C_GetAttributeValueValidRsaContext( void )
 
         TEST_ASSERT_EQUAL( CKR_OK, xResult );
 
-/* -------------------------------------------------------------------------------------------------------------------- */   
+/* -------------------------------------------------------------------------------------------------------------------- */
 
         /* CKA_PUBLIC_EXPONENT case */
         /* Failure path */
-        xTemplates[ 0 ].type = CKA_PUBLIC_EXPONENT ;
+        xTemplates[ 0 ].type = CKA_PUBLIC_EXPONENT;
         xTemplates[ 0 ].pValue = &ulPoint;
-        xTemplates[ 0 ].ulValueLen = ( sizeof( mbedtls_mpi ) );        
+        xTemplates[ 0 ].ulValueLen = ( sizeof( mbedtls_mpi ) );
 
         mbedtls_pk_init_ExpectAnyArgs();
         mbedtls_pk_init_ReturnThruPtr_ctx( &xKeyContext );
@@ -3639,10 +3639,10 @@ void test_pkcs11_C_GetAttributeValueValidRsaContext( void )
 
         /* CKA_PUBLIC_EXPONENT case */
         /* Success path */
-        xTemplates[ 0 ].type = CKA_PUBLIC_EXPONENT ;
+        xTemplates[ 0 ].type = CKA_PUBLIC_EXPONENT;
         xTemplates[ 0 ].pValue = &ulPoint;
         xTemplates[ 0 ].ulValueLen = ( sizeof( mbedtls_mpi ) );
-        
+
         mbedtls_pk_init_ExpectAnyArgs();
         mbedtls_pk_init_ReturnThruPtr_ctx( &xKeyContext );
         mbedtls_mpi_grow_ExpectAnyArgsAndReturn( 0 );
@@ -3651,13 +3651,13 @@ void test_pkcs11_C_GetAttributeValueValidRsaContext( void )
 
         TEST_ASSERT_EQUAL( CKR_OK, xResult );
 
-/* -------------------------------------------------------------------------------------------------------------------- */   
+/* -------------------------------------------------------------------------------------------------------------------- */
 
         /* CKA_PRIME_1 case */
         /* Failure path */
         xTemplates[ 0 ].type = CKA_PRIME_1;
         xTemplates[ 0 ].pValue = &ulPoint;
-        xTemplates[ 0 ].ulValueLen = ( sizeof( mbedtls_mpi ) );        
+        xTemplates[ 0 ].ulValueLen = ( sizeof( mbedtls_mpi ) );
 
         mbedtls_pk_init_ExpectAnyArgs();
         mbedtls_pk_init_ReturnThruPtr_ctx( &xKeyContext );
@@ -3671,7 +3671,7 @@ void test_pkcs11_C_GetAttributeValueValidRsaContext( void )
         xTemplates[ 0 ].type = CKA_PRIME_1;
         xTemplates[ 0 ].pValue = &ulPoint;
         xTemplates[ 0 ].ulValueLen = ( sizeof( mbedtls_mpi ) );
-        
+
         mbedtls_pk_init_ExpectAnyArgs();
         mbedtls_pk_init_ReturnThruPtr_ctx( &xKeyContext );
         mbedtls_mpi_grow_ExpectAnyArgsAndReturn( 0 );
@@ -3680,13 +3680,13 @@ void test_pkcs11_C_GetAttributeValueValidRsaContext( void )
 
         TEST_ASSERT_EQUAL( CKR_OK, xResult );
 
-/* -------------------------------------------------------------------------------------------------------------------- */   
+/* -------------------------------------------------------------------------------------------------------------------- */
 
         /* CKA_PRIME_2 case */
         /* Failure path */
         xTemplates[ 0 ].type = CKA_PRIME_2;
         xTemplates[ 0 ].pValue = &ulPoint;
-        xTemplates[ 0 ].ulValueLen = ( sizeof( mbedtls_mpi ) );        
+        xTemplates[ 0 ].ulValueLen = ( sizeof( mbedtls_mpi ) );
 
         mbedtls_pk_init_ExpectAnyArgs();
         mbedtls_pk_init_ReturnThruPtr_ctx( &xKeyContext );
@@ -3700,7 +3700,7 @@ void test_pkcs11_C_GetAttributeValueValidRsaContext( void )
         xTemplates[ 0 ].type = CKA_PRIME_2;
         xTemplates[ 0 ].pValue = &ulPoint;
         xTemplates[ 0 ].ulValueLen = ( sizeof( mbedtls_mpi ) );
-        
+
         mbedtls_pk_init_ExpectAnyArgs();
         mbedtls_pk_init_ReturnThruPtr_ctx( &xKeyContext );
         mbedtls_mpi_grow_ExpectAnyArgsAndReturn( 0 );
@@ -3709,13 +3709,13 @@ void test_pkcs11_C_GetAttributeValueValidRsaContext( void )
 
         TEST_ASSERT_EQUAL( CKR_OK, xResult );
 
-/* -------------------------------------------------------------------------------------------------------------------- */   
+/* -------------------------------------------------------------------------------------------------------------------- */
 
         /* CKA_PRIVATE_EXPONENT case */
         /* Failure path */
-        xTemplates[ 0 ].type = CKA_PRIVATE_EXPONENT ;
+        xTemplates[ 0 ].type = CKA_PRIVATE_EXPONENT;
         xTemplates[ 0 ].pValue = &ulPoint;
-        xTemplates[ 0 ].ulValueLen = ( sizeof( mbedtls_mpi ) );        
+        xTemplates[ 0 ].ulValueLen = ( sizeof( mbedtls_mpi ) );
 
         mbedtls_pk_init_ExpectAnyArgs();
         mbedtls_pk_init_ReturnThruPtr_ctx( &xKeyContext );
@@ -3726,10 +3726,10 @@ void test_pkcs11_C_GetAttributeValueValidRsaContext( void )
 
         /* CKA_PRIVATE_EXPONENT case */
         /* Success path */
-        xTemplates[ 0 ].type = CKA_PRIVATE_EXPONENT ;
+        xTemplates[ 0 ].type = CKA_PRIVATE_EXPONENT;
         xTemplates[ 0 ].pValue = &ulPoint;
         xTemplates[ 0 ].ulValueLen = ( sizeof( mbedtls_mpi ) );
-        
+
         mbedtls_pk_init_ExpectAnyArgs();
         mbedtls_pk_init_ReturnThruPtr_ctx( &xKeyContext );
         mbedtls_mpi_grow_ExpectAnyArgsAndReturn( 0 );
@@ -3738,13 +3738,13 @@ void test_pkcs11_C_GetAttributeValueValidRsaContext( void )
 
         TEST_ASSERT_EQUAL( CKR_OK, xResult );
 
-/* -------------------------------------------------------------------------------------------------------------------- */   
+/* -------------------------------------------------------------------------------------------------------------------- */
 
         /* CKA_PRIVATE_EXPONENT case */
         /* Failure path */
-        xTemplates[ 0 ].type = CKA_PRIVATE_EXPONENT ;
+        xTemplates[ 0 ].type = CKA_PRIVATE_EXPONENT;
         xTemplates[ 0 ].pValue = &ulPoint;
-        xTemplates[ 0 ].ulValueLen = ( sizeof( mbedtls_mpi ) );        
+        xTemplates[ 0 ].ulValueLen = ( sizeof( mbedtls_mpi ) );
 
         mbedtls_pk_init_ExpectAnyArgs();
         mbedtls_pk_init_ReturnThruPtr_ctx( &xKeyContext );
@@ -3755,10 +3755,10 @@ void test_pkcs11_C_GetAttributeValueValidRsaContext( void )
 
         /* CKA_PRIVATE_EXPONENT case */
         /* Success path */
-        xTemplates[ 0 ].type = CKA_PRIVATE_EXPONENT ;
+        xTemplates[ 0 ].type = CKA_PRIVATE_EXPONENT;
         xTemplates[ 0 ].pValue = &ulPoint;
         xTemplates[ 0 ].ulValueLen = ( sizeof( mbedtls_mpi ) );
-        
+
         mbedtls_pk_init_ExpectAnyArgs();
         mbedtls_pk_init_ReturnThruPtr_ctx( &xKeyContext );
         mbedtls_mpi_grow_ExpectAnyArgsAndReturn( 0 );
@@ -3767,13 +3767,13 @@ void test_pkcs11_C_GetAttributeValueValidRsaContext( void )
 
         TEST_ASSERT_EQUAL( CKR_OK, xResult );
 
-/* -------------------------------------------------------------------------------------------------------------------- */   
+/* -------------------------------------------------------------------------------------------------------------------- */
 
         /* CKA_EXPONENT_1 case */
         /* Failure path */
         xTemplates[ 0 ].type = CKA_EXPONENT_1;
         xTemplates[ 0 ].pValue = &ulPoint;
-        xTemplates[ 0 ].ulValueLen = ( sizeof( mbedtls_mpi ) );        
+        xTemplates[ 0 ].ulValueLen = ( sizeof( mbedtls_mpi ) );
 
         mbedtls_pk_init_ExpectAnyArgs();
         mbedtls_pk_init_ReturnThruPtr_ctx( &xKeyContext );
@@ -3787,7 +3787,7 @@ void test_pkcs11_C_GetAttributeValueValidRsaContext( void )
         xTemplates[ 0 ].type = CKA_EXPONENT_1;
         xTemplates[ 0 ].pValue = &ulPoint;
         xTemplates[ 0 ].ulValueLen = ( sizeof( mbedtls_mpi ) );
-        
+
         mbedtls_pk_init_ExpectAnyArgs();
         mbedtls_pk_init_ReturnThruPtr_ctx( &xKeyContext );
         mbedtls_mpi_grow_ExpectAnyArgsAndReturn( 0 );
@@ -3802,7 +3802,7 @@ void test_pkcs11_C_GetAttributeValueValidRsaContext( void )
         /* Failure path */
         xTemplates[ 0 ].type = CKA_EXPONENT_2;
         xTemplates[ 0 ].pValue = &ulPoint;
-        xTemplates[ 0 ].ulValueLen = ( sizeof( mbedtls_mpi ) );        
+        xTemplates[ 0 ].ulValueLen = ( sizeof( mbedtls_mpi ) );
 
         mbedtls_pk_init_ExpectAnyArgs();
         mbedtls_pk_init_ReturnThruPtr_ctx( &xKeyContext );
@@ -3816,7 +3816,7 @@ void test_pkcs11_C_GetAttributeValueValidRsaContext( void )
         xTemplates[ 0 ].type = CKA_EXPONENT_2;
         xTemplates[ 0 ].pValue = &ulPoint;
         xTemplates[ 0 ].ulValueLen = ( sizeof( mbedtls_mpi ) );
-        
+
         mbedtls_pk_init_ExpectAnyArgs();
         mbedtls_pk_init_ReturnThruPtr_ctx( &xKeyContext );
         mbedtls_mpi_grow_ExpectAnyArgsAndReturn( 0 );
@@ -3831,7 +3831,7 @@ void test_pkcs11_C_GetAttributeValueValidRsaContext( void )
         /* Failure path */
         xTemplates[ 0 ].type = CKA_COEFFICIENT;
         xTemplates[ 0 ].pValue = &ulPoint;
-        xTemplates[ 0 ].ulValueLen = ( sizeof( mbedtls_mpi ) );        
+        xTemplates[ 0 ].ulValueLen = ( sizeof( mbedtls_mpi ) );
 
         mbedtls_pk_init_ExpectAnyArgs();
         mbedtls_pk_init_ReturnThruPtr_ctx( &xKeyContext );
@@ -3845,7 +3845,7 @@ void test_pkcs11_C_GetAttributeValueValidRsaContext( void )
         xTemplates[ 0 ].type = CKA_COEFFICIENT;
         xTemplates[ 0 ].pValue = &ulPoint;
         xTemplates[ 0 ].ulValueLen = ( sizeof( mbedtls_mpi ) );
-        
+
         mbedtls_pk_init_ExpectAnyArgs();
         mbedtls_pk_init_ReturnThruPtr_ctx( &xKeyContext );
         mbedtls_mpi_grow_ExpectAnyArgsAndReturn( 0 );
@@ -3855,7 +3855,6 @@ void test_pkcs11_C_GetAttributeValueValidRsaContext( void )
         TEST_ASSERT_EQUAL( CKR_OK, xResult );
 
 /* -------------------------------------------------------------------------------------------------------------------- */
-
     }
 
     if( TEST_PROTECT() )
@@ -3946,8 +3945,8 @@ void test_pkcs11_C_GetAttributeValueModulusBadPath( void )
 
         TEST_ASSERT_EQUAL( CKR_OK, xResult );
         TEST_ASSERT_EQUAL( sizeof( mbedtls_mpi ), xTemplates[ 0 ].ulValueLen );
-        
-/* -------------------------------------------------------------------------------------------------------------------- */   
+
+/* -------------------------------------------------------------------------------------------------------------------- */
 
         /* MODULUS case*/
         /* CKR_BUFFER_TOO_SMALL should be returned when mbedtls return buffer too small. */
@@ -3960,7 +3959,6 @@ void test_pkcs11_C_GetAttributeValueModulusBadPath( void )
         TEST_ASSERT_EQUAL( CKR_BUFFER_TOO_SMALL, xResult );
 
 /* -------------------------------------------------------------------------------------------------------------------- */
-
     }
 
     if( TEST_PROTECT() )

--- a/test/pkcs11_mbedtls_utest/core_pkcs11_mbedtls_utest.c
+++ b/test/pkcs11_mbedtls_utest/core_pkcs11_mbedtls_utest.c
@@ -3275,7 +3275,7 @@ void test_pkcs11_C_GetAttributeValueAttParsing( void )
         mbedtls_ecp_tls_write_point_IgnoreAndReturn( 1 );
 
         /* Unknown attribute. */
-        xTemplate.type = CKA_MODULUS;
+        xTemplate.type = CKA_SUBPRIME;
 
         xResult = C_GetAttributeValue( xSession, xObject, ( CK_ATTRIBUTE_PTR ) &xTemplate, ulCount );
         TEST_ASSERT_EQUAL( CKR_ATTRIBUTE_TYPE_INVALID, xResult );
@@ -3393,8 +3393,8 @@ void test_pkcs11_C_GetAttributeValueMultipleAttParsing( void )
         xTemplates[ 0 ].pValue = NULL;
         xTemplates[ 0 ].ulValueLen = 0;
 
-        /* CKR_ATTRIBUTE_TYPE_INVALID should be returned for unknow attribute CKA_MODULUS. */
-        xTemplates[ 1 ].type = CKA_MODULUS;
+        /* CKR_ATTRIBUTE_TYPE_INVALID should be returned for unknow attribute CKA_SUBPRIME. */
+        xTemplates[ 1 ].type = CKA_SUBPRIME;
         xTemplates[ 1 ].pValue = NULL;
         xTemplates[ 1 ].ulValueLen = 0;
         xResult = C_GetAttributeValue( xSession, xObject, ( CK_ATTRIBUTE_PTR ) &xTemplates, ulCount );
@@ -3405,8 +3405,8 @@ void test_pkcs11_C_GetAttributeValueMultipleAttParsing( void )
         TEST_ASSERT_EQUAL( CK_UNAVAILABLE_INFORMATION, xTemplates[ 1 ].ulValueLen );
 
         /* Swap the sequence EC Point Case and unknown attribute case. */
-        /* CKR_ATTRIBUTE_TYPE_INVALID should be returned for unknow attribute CKA_MODULUS. */
-        xTemplates[ 0 ].type = CKA_MODULUS;
+        /* CKR_ATTRIBUTE_TYPE_INVALID should be returned for unknow attribute CKA_SUBPRIME. */
+        xTemplates[ 0 ].type = CKA_SUBPRIME;
         xTemplates[ 0 ].pValue = NULL;
         xTemplates[ 0 ].ulValueLen = 0;
 
@@ -3454,9 +3454,9 @@ void test_pkcs11_C_GetAttributeValueMultipleAttParsing( void )
         TEST_ASSERT_EQUAL( pkcs11EC_POINT_LENGTH, xTemplates[ 0 ].ulValueLen );
         TEST_ASSERT_EQUAL( CK_UNAVAILABLE_INFORMATION, xTemplates[ 1 ].ulValueLen );
 
-        /* CKR_ATTRIBUTE_SENSITIVE should be returned when getting CKA_PRIVATE_EXPONENT type. */
+        /* CKR_ATTRIBUTE_SENSITIVE should be returned when getting CKA_VALUE type. */
         mbedtls_pk_parse_key_ExpectAnyArgsAndReturn( 0 );
-        xTemplates[ 0 ].type = CKA_PRIVATE_EXPONENT;
+        xTemplates[ 0 ].type = CKA_VALUE;
         xTemplates[ 0 ].pValue = NULL;
         xTemplates[ 0 ].ulValueLen = 0;
 
@@ -3476,9 +3476,9 @@ void test_pkcs11_C_GetAttributeValueMultipleAttParsing( void )
         xTemplates[ 0 ].pValue = NULL;
         xTemplates[ 0 ].ulValueLen = 0;
 
-        /* CKR_ATTRIBUTE_SENSITIVE should be returned when getting CKA_PRIVATE_EXPONENT type. */
+        /* CKR_ATTRIBUTE_SENSITIVE should be returned when getting CKA_VALUE type. */
         mbedtls_pk_parse_key_ExpectAnyArgsAndReturn( 0 );
-        xTemplates[ 1 ].type = CKA_PRIVATE_EXPONENT;
+        xTemplates[ 1 ].type = CKA_VALUE;
         xTemplates[ 1 ].pValue = NULL;
         xTemplates[ 1 ].ulValueLen = 0;
 
@@ -3525,8 +3525,8 @@ void test_pkcs11_C_GetAttributeValueMultipleAttParsing( void )
         TEST_ASSERT_EQUAL( pkcs11EC_POINT_LENGTH, xTemplates[ 0 ].ulValueLen );
         TEST_ASSERT_EQUAL( CK_UNAVAILABLE_INFORMATION, xTemplates[ 1 ].ulValueLen );
 
-        /* CKR_ATTRIBUTE_TYPE_INVALID should be returned for unknow attribute CKA_MODULUS. */
-        xTemplates[ 0 ].type = CKA_MODULUS;
+        /* CKR_ATTRIBUTE_TYPE_INVALID should be returned for unknow attribute CKA_SUBPRIME. */
+        xTemplates[ 0 ].type = CKA_SUBPRIME;
         xTemplates[ 0 ].pValue = NULL;
         xTemplates[ 0 ].ulValueLen = 0;
 
@@ -3688,7 +3688,7 @@ void test_pkcs11_C_GetAttributeValuePrivKey( void )
         TEST_ASSERT_EQUAL( CKR_ATTRIBUTE_VALUE_INVALID, xResult );
         TEST_ASSERT_EQUAL( CK_UNAVAILABLE_INFORMATION, xTemplate.ulValueLen );
 
-        xTemplate.type = CKA_PRIVATE_EXPONENT;
+        xTemplate.type = CKA_VALUE;
         mbedtls_pk_parse_key_ExpectAnyArgsAndReturn( 0 );
         xResult = C_GetAttributeValue( xSession, xObject, ( CK_ATTRIBUTE_PTR ) &xTemplate, ulCount );
         TEST_ASSERT_EQUAL( CKR_ATTRIBUTE_SENSITIVE, xResult );

--- a/test/pkcs11_mbedtls_utest/core_pkcs11_mbedtls_utest.c
+++ b/test/pkcs11_mbedtls_utest/core_pkcs11_mbedtls_utest.c
@@ -3572,6 +3572,409 @@ void test_pkcs11_C_GetAttributeValueMultipleAttParsing( void )
  * @brief C_GetAttributeValue paths.
  *
  */
+void test_pkcs11_C_GetAttributeValueValidRsaContext( void )
+{
+    CK_RV xResult = CKR_OK;
+    CK_SESSION_HANDLE xSession = 0;
+    CK_OBJECT_HANDLE xObject = 0;
+    CK_ULONG ulCount = 1;
+    CK_ATTRIBUTE xTemplates[ 1 ] = { 0 };
+    mbedtls_pk_context xKeyContext = { NULL, &xResult };
+    CK_BYTE ulPoint[ pkcs11EC_POINT_LENGTH ] = { 0 };
+
+    prvCommonInitStubs( &xSession );
+
+    if( TEST_PROTECT() )
+    {
+        xResult = prvCreateEcPriv( &xSession, &xObject );
+        TEST_ASSERT_EQUAL( CKR_OK, xResult );
+
+        mbedtls_mpi_init_Ignore();
+        mbedtls_x509_crt_init_CMockIgnore();
+        PKCS11_PAL_GetObjectValueCleanup_CMockIgnore();
+        mbedtls_pk_free_CMockIgnore();
+        mbedtls_x509_crt_free_CMockIgnore();
+
+        /* CKA_MODULUS case */
+        /* Failure path */
+        xTemplates[ 0 ].type = CKA_MODULUS;
+        xTemplates[ 0 ].pValue = &ulPoint;
+        xTemplates[ 0 ].ulValueLen = ( sizeof( mbedtls_mpi ) );        
+
+        mbedtls_pk_init_ExpectAnyArgs();
+        mbedtls_pk_init_ReturnThruPtr_ctx( &xKeyContext );
+        mbedtls_mpi_grow_ExpectAnyArgsAndReturn( 1 );
+        xResult = C_GetAttributeValue( xSession, xObject, ( CK_ATTRIBUTE_PTR ) &xTemplates, ulCount );
+
+        TEST_ASSERT_EQUAL( CKR_FUNCTION_FAILED, xResult );
+
+        /* CKA_MODULUS case */
+        /* Success path */
+        xTemplates[ 0 ].type = CKA_MODULUS;
+        xTemplates[ 0 ].pValue = &ulPoint;
+        xTemplates[ 0 ].ulValueLen = ( sizeof( mbedtls_mpi ) );
+        
+        mbedtls_pk_init_ExpectAnyArgs();
+        mbedtls_pk_init_ReturnThruPtr_ctx( &xKeyContext );
+        mbedtls_mpi_grow_ExpectAnyArgsAndReturn( 0 );
+        mbedtls_rsa_export_ExpectAnyArgsAndReturn( 0 );
+        xResult = C_GetAttributeValue( xSession, xObject, ( CK_ATTRIBUTE_PTR ) &xTemplates, ulCount );
+
+        TEST_ASSERT_EQUAL( CKR_OK, xResult );
+
+/* -------------------------------------------------------------------------------------------------------------------- */   
+
+        /* CKA_PUBLIC_EXPONENT case */
+        /* Failure path */
+        xTemplates[ 0 ].type = CKA_PUBLIC_EXPONENT ;
+        xTemplates[ 0 ].pValue = &ulPoint;
+        xTemplates[ 0 ].ulValueLen = ( sizeof( mbedtls_mpi ) );        
+
+        mbedtls_pk_init_ExpectAnyArgs();
+        mbedtls_pk_init_ReturnThruPtr_ctx( &xKeyContext );
+        mbedtls_mpi_grow_ExpectAnyArgsAndReturn( 1 );
+        xResult = C_GetAttributeValue( xSession, xObject, ( CK_ATTRIBUTE_PTR ) &xTemplates, ulCount );
+
+        TEST_ASSERT_EQUAL( CKR_FUNCTION_FAILED, xResult );
+
+        /* CKA_PUBLIC_EXPONENT case */
+        /* Success path */
+        xTemplates[ 0 ].type = CKA_PUBLIC_EXPONENT ;
+        xTemplates[ 0 ].pValue = &ulPoint;
+        xTemplates[ 0 ].ulValueLen = ( sizeof( mbedtls_mpi ) );
+        
+        mbedtls_pk_init_ExpectAnyArgs();
+        mbedtls_pk_init_ReturnThruPtr_ctx( &xKeyContext );
+        mbedtls_mpi_grow_ExpectAnyArgsAndReturn( 0 );
+        mbedtls_rsa_export_ExpectAnyArgsAndReturn( 0 );
+        xResult = C_GetAttributeValue( xSession, xObject, ( CK_ATTRIBUTE_PTR ) &xTemplates, ulCount );
+
+        TEST_ASSERT_EQUAL( CKR_OK, xResult );
+
+/* -------------------------------------------------------------------------------------------------------------------- */   
+
+        /* CKA_PRIME_1 case */
+        /* Failure path */
+        xTemplates[ 0 ].type = CKA_PRIME_1;
+        xTemplates[ 0 ].pValue = &ulPoint;
+        xTemplates[ 0 ].ulValueLen = ( sizeof( mbedtls_mpi ) );        
+
+        mbedtls_pk_init_ExpectAnyArgs();
+        mbedtls_pk_init_ReturnThruPtr_ctx( &xKeyContext );
+        mbedtls_mpi_grow_ExpectAnyArgsAndReturn( 1 );
+        xResult = C_GetAttributeValue( xSession, xObject, ( CK_ATTRIBUTE_PTR ) &xTemplates, ulCount );
+
+        TEST_ASSERT_EQUAL( CKR_FUNCTION_FAILED, xResult );
+
+        /* CKA_PRIME_1 case */
+        /* Success path */
+        xTemplates[ 0 ].type = CKA_PRIME_1;
+        xTemplates[ 0 ].pValue = &ulPoint;
+        xTemplates[ 0 ].ulValueLen = ( sizeof( mbedtls_mpi ) );
+        
+        mbedtls_pk_init_ExpectAnyArgs();
+        mbedtls_pk_init_ReturnThruPtr_ctx( &xKeyContext );
+        mbedtls_mpi_grow_ExpectAnyArgsAndReturn( 0 );
+        mbedtls_rsa_export_ExpectAnyArgsAndReturn( 0 );
+        xResult = C_GetAttributeValue( xSession, xObject, ( CK_ATTRIBUTE_PTR ) &xTemplates, ulCount );
+
+        TEST_ASSERT_EQUAL( CKR_OK, xResult );
+
+/* -------------------------------------------------------------------------------------------------------------------- */   
+
+        /* CKA_PRIME_2 case */
+        /* Failure path */
+        xTemplates[ 0 ].type = CKA_PRIME_2;
+        xTemplates[ 0 ].pValue = &ulPoint;
+        xTemplates[ 0 ].ulValueLen = ( sizeof( mbedtls_mpi ) );        
+
+        mbedtls_pk_init_ExpectAnyArgs();
+        mbedtls_pk_init_ReturnThruPtr_ctx( &xKeyContext );
+        mbedtls_mpi_grow_ExpectAnyArgsAndReturn( 1 );
+        xResult = C_GetAttributeValue( xSession, xObject, ( CK_ATTRIBUTE_PTR ) &xTemplates, ulCount );
+
+        TEST_ASSERT_EQUAL( CKR_FUNCTION_FAILED, xResult );
+
+        /* CKA_PRIME_2 case */
+        /* Success path */
+        xTemplates[ 0 ].type = CKA_PRIME_2;
+        xTemplates[ 0 ].pValue = &ulPoint;
+        xTemplates[ 0 ].ulValueLen = ( sizeof( mbedtls_mpi ) );
+        
+        mbedtls_pk_init_ExpectAnyArgs();
+        mbedtls_pk_init_ReturnThruPtr_ctx( &xKeyContext );
+        mbedtls_mpi_grow_ExpectAnyArgsAndReturn( 0 );
+        mbedtls_rsa_export_ExpectAnyArgsAndReturn( 0 );
+        xResult = C_GetAttributeValue( xSession, xObject, ( CK_ATTRIBUTE_PTR ) &xTemplates, ulCount );
+
+        TEST_ASSERT_EQUAL( CKR_OK, xResult );
+
+/* -------------------------------------------------------------------------------------------------------------------- */   
+
+        /* CKA_PRIVATE_EXPONENT case */
+        /* Failure path */
+        xTemplates[ 0 ].type = CKA_PRIVATE_EXPONENT ;
+        xTemplates[ 0 ].pValue = &ulPoint;
+        xTemplates[ 0 ].ulValueLen = ( sizeof( mbedtls_mpi ) );        
+
+        mbedtls_pk_init_ExpectAnyArgs();
+        mbedtls_pk_init_ReturnThruPtr_ctx( &xKeyContext );
+        mbedtls_mpi_grow_ExpectAnyArgsAndReturn( 1 );
+        xResult = C_GetAttributeValue( xSession, xObject, ( CK_ATTRIBUTE_PTR ) &xTemplates, ulCount );
+
+        TEST_ASSERT_EQUAL( CKR_FUNCTION_FAILED, xResult );
+
+        /* CKA_PRIVATE_EXPONENT case */
+        /* Success path */
+        xTemplates[ 0 ].type = CKA_PRIVATE_EXPONENT ;
+        xTemplates[ 0 ].pValue = &ulPoint;
+        xTemplates[ 0 ].ulValueLen = ( sizeof( mbedtls_mpi ) );
+        
+        mbedtls_pk_init_ExpectAnyArgs();
+        mbedtls_pk_init_ReturnThruPtr_ctx( &xKeyContext );
+        mbedtls_mpi_grow_ExpectAnyArgsAndReturn( 0 );
+        mbedtls_rsa_export_ExpectAnyArgsAndReturn( 0 );
+        xResult = C_GetAttributeValue( xSession, xObject, ( CK_ATTRIBUTE_PTR ) &xTemplates, ulCount );
+
+        TEST_ASSERT_EQUAL( CKR_OK, xResult );
+
+/* -------------------------------------------------------------------------------------------------------------------- */   
+
+        /* CKA_PRIVATE_EXPONENT case */
+        /* Failure path */
+        xTemplates[ 0 ].type = CKA_PRIVATE_EXPONENT ;
+        xTemplates[ 0 ].pValue = &ulPoint;
+        xTemplates[ 0 ].ulValueLen = ( sizeof( mbedtls_mpi ) );        
+
+        mbedtls_pk_init_ExpectAnyArgs();
+        mbedtls_pk_init_ReturnThruPtr_ctx( &xKeyContext );
+        mbedtls_mpi_grow_ExpectAnyArgsAndReturn( 1 );
+        xResult = C_GetAttributeValue( xSession, xObject, ( CK_ATTRIBUTE_PTR ) &xTemplates, ulCount );
+
+        TEST_ASSERT_EQUAL( CKR_FUNCTION_FAILED, xResult );
+
+        /* CKA_PRIVATE_EXPONENT case */
+        /* Success path */
+        xTemplates[ 0 ].type = CKA_PRIVATE_EXPONENT ;
+        xTemplates[ 0 ].pValue = &ulPoint;
+        xTemplates[ 0 ].ulValueLen = ( sizeof( mbedtls_mpi ) );
+        
+        mbedtls_pk_init_ExpectAnyArgs();
+        mbedtls_pk_init_ReturnThruPtr_ctx( &xKeyContext );
+        mbedtls_mpi_grow_ExpectAnyArgsAndReturn( 0 );
+        mbedtls_rsa_export_ExpectAnyArgsAndReturn( 0 );
+        xResult = C_GetAttributeValue( xSession, xObject, ( CK_ATTRIBUTE_PTR ) &xTemplates, ulCount );
+
+        TEST_ASSERT_EQUAL( CKR_OK, xResult );
+
+/* -------------------------------------------------------------------------------------------------------------------- */   
+
+        /* CKA_EXPONENT_1 case */
+        /* Failure path */
+        xTemplates[ 0 ].type = CKA_EXPONENT_1;
+        xTemplates[ 0 ].pValue = &ulPoint;
+        xTemplates[ 0 ].ulValueLen = ( sizeof( mbedtls_mpi ) );        
+
+        mbedtls_pk_init_ExpectAnyArgs();
+        mbedtls_pk_init_ReturnThruPtr_ctx( &xKeyContext );
+        mbedtls_mpi_grow_ExpectAnyArgsAndReturn( 1 );
+        xResult = C_GetAttributeValue( xSession, xObject, ( CK_ATTRIBUTE_PTR ) &xTemplates, ulCount );
+
+        TEST_ASSERT_EQUAL( CKR_FUNCTION_FAILED, xResult );
+
+        /* CKA_EXPONENT_1 case */
+        /* Success path */
+        xTemplates[ 0 ].type = CKA_EXPONENT_1;
+        xTemplates[ 0 ].pValue = &ulPoint;
+        xTemplates[ 0 ].ulValueLen = ( sizeof( mbedtls_mpi ) );
+        
+        mbedtls_pk_init_ExpectAnyArgs();
+        mbedtls_pk_init_ReturnThruPtr_ctx( &xKeyContext );
+        mbedtls_mpi_grow_ExpectAnyArgsAndReturn( 0 );
+        mbedtls_rsa_export_crt_ExpectAnyArgsAndReturn( 0 );
+        xResult = C_GetAttributeValue( xSession, xObject, ( CK_ATTRIBUTE_PTR ) &xTemplates, ulCount );
+
+        TEST_ASSERT_EQUAL( CKR_OK, xResult );
+
+/* -------------------------------------------------------------------------------------------------------------------- */
+
+        /* CKA_EXPONENT_2 case */
+        /* Failure path */
+        xTemplates[ 0 ].type = CKA_EXPONENT_2;
+        xTemplates[ 0 ].pValue = &ulPoint;
+        xTemplates[ 0 ].ulValueLen = ( sizeof( mbedtls_mpi ) );        
+
+        mbedtls_pk_init_ExpectAnyArgs();
+        mbedtls_pk_init_ReturnThruPtr_ctx( &xKeyContext );
+        mbedtls_mpi_grow_ExpectAnyArgsAndReturn( 1 );
+        xResult = C_GetAttributeValue( xSession, xObject, ( CK_ATTRIBUTE_PTR ) &xTemplates, ulCount );
+
+        TEST_ASSERT_EQUAL( CKR_FUNCTION_FAILED, xResult );
+
+        /* CKA_EXPONENT_2 case */
+        /* Success path */
+        xTemplates[ 0 ].type = CKA_EXPONENT_2;
+        xTemplates[ 0 ].pValue = &ulPoint;
+        xTemplates[ 0 ].ulValueLen = ( sizeof( mbedtls_mpi ) );
+        
+        mbedtls_pk_init_ExpectAnyArgs();
+        mbedtls_pk_init_ReturnThruPtr_ctx( &xKeyContext );
+        mbedtls_mpi_grow_ExpectAnyArgsAndReturn( 0 );
+        mbedtls_rsa_export_crt_ExpectAnyArgsAndReturn( 0 );
+        xResult = C_GetAttributeValue( xSession, xObject, ( CK_ATTRIBUTE_PTR ) &xTemplates, ulCount );
+
+        TEST_ASSERT_EQUAL( CKR_OK, xResult );
+
+/* -------------------------------------------------------------------------------------------------------------------- */
+
+        /* CKA_COEFFICIENT case */
+        /* Failure path */
+        xTemplates[ 0 ].type = CKA_COEFFICIENT;
+        xTemplates[ 0 ].pValue = &ulPoint;
+        xTemplates[ 0 ].ulValueLen = ( sizeof( mbedtls_mpi ) );        
+
+        mbedtls_pk_init_ExpectAnyArgs();
+        mbedtls_pk_init_ReturnThruPtr_ctx( &xKeyContext );
+        mbedtls_mpi_grow_ExpectAnyArgsAndReturn( 1 );
+        xResult = C_GetAttributeValue( xSession, xObject, ( CK_ATTRIBUTE_PTR ) &xTemplates, ulCount );
+
+        TEST_ASSERT_EQUAL( CKR_FUNCTION_FAILED, xResult );
+
+        /* CKA_COEFFICIENT case */
+        /* Success path */
+        xTemplates[ 0 ].type = CKA_COEFFICIENT;
+        xTemplates[ 0 ].pValue = &ulPoint;
+        xTemplates[ 0 ].ulValueLen = ( sizeof( mbedtls_mpi ) );
+        
+        mbedtls_pk_init_ExpectAnyArgs();
+        mbedtls_pk_init_ReturnThruPtr_ctx( &xKeyContext );
+        mbedtls_mpi_grow_ExpectAnyArgsAndReturn( 0 );
+        mbedtls_rsa_export_crt_ExpectAnyArgsAndReturn( 0 );
+        xResult = C_GetAttributeValue( xSession, xObject, ( CK_ATTRIBUTE_PTR ) &xTemplates, ulCount );
+
+        TEST_ASSERT_EQUAL( CKR_OK, xResult );
+
+/* -------------------------------------------------------------------------------------------------------------------- */
+
+    }
+
+    if( TEST_PROTECT() )
+    {
+        prvCommonDeinitStubs( &xSession );
+    }
+}
+
+/*!
+ * @brief C_GetAttributeValue paths.
+ *
+ */
+void test_pkcs11_C_GetAttributeValueModulusNullRsaContext( void )
+{
+    CK_RV xResult = CKR_OK;
+    CK_SESSION_HANDLE xSession = 0;
+    CK_OBJECT_HANDLE xObject = 0;
+    CK_ULONG ulCount = 1;
+    CK_ATTRIBUTE xTemplates[ 1 ] = { 0 };
+    mbedtls_pk_context xKeyContext = { NULL, NULL };
+    CK_BYTE ulPoint[ pkcs11EC_POINT_LENGTH ] = { 0 };
+
+    prvCommonInitStubs( &xSession );
+
+    if( TEST_PROTECT() )
+    {
+        xResult = prvCreateEcPriv( &xSession, &xObject );
+        TEST_ASSERT_EQUAL( CKR_OK, xResult );
+
+        mbedtls_pk_init_ExpectAnyArgs();
+        mbedtls_pk_init_ReturnThruPtr_ctx( &xKeyContext );
+        mbedtls_x509_crt_init_CMockIgnore();
+        PKCS11_PAL_GetObjectValueCleanup_CMockIgnore();
+        mbedtls_pk_free_CMockIgnore();
+        mbedtls_x509_crt_free_CMockIgnore();
+
+        /* MODULUS case*/
+        xTemplates[ 0 ].type = CKA_MODULUS;
+        xTemplates[ 0 ].pValue = &ulPoint;
+        xTemplates[ 0 ].ulValueLen = ( sizeof( mbedtls_mpi ) );
+
+        xResult = C_GetAttributeValue( xSession, xObject, ( CK_ATTRIBUTE_PTR ) &xTemplates, ulCount );
+
+        TEST_ASSERT_EQUAL( CKR_FUNCTION_FAILED, xResult );
+        TEST_ASSERT_EQUAL( CK_UNAVAILABLE_INFORMATION, xTemplates[ 0 ].ulValueLen );
+    }
+
+    if( TEST_PROTECT() )
+    {
+        prvCommonDeinitStubs( &xSession );
+    }
+}
+
+
+/*!
+ * @brief C_GetAttributeValue paths.
+ *
+ */
+void test_pkcs11_C_GetAttributeValueModulusBadPath( void )
+{
+    CK_RV xResult = CKR_OK;
+    CK_SESSION_HANDLE xSession = 0;
+    CK_OBJECT_HANDLE xObject = 0;
+    CK_ULONG ulCount = 1;
+    CK_ATTRIBUTE xTemplates[ 1 ] = { 0 };
+    mbedtls_pk_context xKeyContext = { NULL, NULL };
+    CK_BYTE ulPoint[ pkcs11EC_POINT_LENGTH ] = { 0 };
+
+    prvCommonInitStubs( &xSession );
+
+    if( TEST_PROTECT() )
+    {
+        xResult = prvCreateEcPriv( &xSession, &xObject );
+        TEST_ASSERT_EQUAL( CKR_OK, xResult );
+
+        mbedtls_pk_init_CMockIgnore();
+        mbedtls_x509_crt_init_CMockIgnore();
+        PKCS11_PAL_GetObjectValueCleanup_CMockIgnore();
+        mbedtls_pk_free_CMockIgnore();
+        mbedtls_x509_crt_free_CMockIgnore();
+
+        /* MODULUS case*/
+        xTemplates[ 0 ].type = CKA_MODULUS;
+        xTemplates[ 0 ].pValue = NULL;
+        xTemplates[ 0 ].ulValueLen = 0;
+
+        xResult = C_GetAttributeValue( xSession, xObject, ( CK_ATTRIBUTE_PTR ) &xTemplates, ulCount );
+
+        TEST_ASSERT_EQUAL( CKR_OK, xResult );
+        TEST_ASSERT_EQUAL( sizeof( mbedtls_mpi ), xTemplates[ 0 ].ulValueLen );
+        
+/* -------------------------------------------------------------------------------------------------------------------- */   
+
+        /* MODULUS case*/
+        /* CKR_BUFFER_TOO_SMALL should be returned when mbedtls return buffer too small. */
+        xTemplates[ 0 ].type = CKA_MODULUS;
+        xTemplates[ 0 ].pValue = &ulPoint;
+        xTemplates[ 0 ].ulValueLen = ( sizeof( mbedtls_mpi ) - 1 );
+
+        xResult = C_GetAttributeValue( xSession, xObject, ( CK_ATTRIBUTE_PTR ) &xTemplates, ulCount );
+
+        TEST_ASSERT_EQUAL( CKR_BUFFER_TOO_SMALL, xResult );
+
+/* -------------------------------------------------------------------------------------------------------------------- */
+
+    }
+
+    if( TEST_PROTECT() )
+    {
+        prvCommonDeinitStubs( &xSession );
+    }
+}
+
+
+
+/*!
+ * @brief C_GetAttributeValue paths.
+ *
+ */
 void test_pkcs11_C_GetAttributeValuePrivKey( void )
 {
     CK_RV xResult = CKR_OK;

--- a/tools/coverity/README.md
+++ b/tools/coverity/README.md
@@ -1,6 +1,6 @@
 # Static code analysis for corePKCS11 library
 This directory is made for the purpose of statically testing the MISRA C:2012 compliance of corePKCS11 using
-[Synopsys Coverity](https://www.synopsys.com/software-integrity/security-testing/static-analysis-sast.html) static analysis tool.
+[Synopsys Coverity](https://www.blackduck.com/static-analysis-tools-sast/coverity.html) static analysis tool.
 To that end, this directory provides a [configuration file](https://github.com/FreeRTOS/corePKCS11/blob/main/tools/coverity/misra.config) to use when
 building a binary for the tool to analyze.
 


### PR DESCRIPTION
<!--- Title -->

Description
-----------
Presently the library is not able to support TLSv1.3, this is because it does not allow exporting RSA public attributes. It does not populate the attribute values for an RSA key using the `mbedtls_rsa_context` due to which the certificate verification fails. 

This PR adds a new function that populates attribute values for an RSA key from the mbed TLS context.

Test Steps
-----------
<!-- Describe the steps to reproduce. -->
For now it is only tested using the the corePKCS MQTT Mutual Auth Demo that builds with the changes and is able to create a successful TLS connection with the broker. 

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have tested my changes. No regression in existing tests.
- [ ] I have modified and/or added unit-tests to cover the code changes in this Pull Request.

Related Issue
-----------
<!-- If any, please provide issue ID. -->
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
